### PR TITLE
Fix Zod strict objects `additionalProperties` mapping

### DIFF
--- a/src/create/schema/object.test.ts
+++ b/src/create/schema/object.test.ts
@@ -37,7 +37,7 @@ describe('createObjectSchema', () => {
         },
       },
       required: ['a'],
-      additionalProperties: true,
+      additionalProperties: false,
     };
     const schema = z.strictObject({
       a: z.string(),

--- a/src/create/schema/object.ts
+++ b/src/create/schema/object.ts
@@ -67,7 +67,7 @@ export const createObjectSchemaFromShape = (
   type: 'object',
   properties: mapProperties(shape, components),
   required: mapRequired(shape),
-  ...(strict && { additionalProperties: strict }),
+  ...(strict && { additionalProperties: false }),
 });
 
 export const mapRequired = (


### PR DESCRIPTION
At the moment Zod Strict Objects render `additionalProperties: true` when they should be rendering `additionalProperties: false`