### PR TITLE
Add override to `ZodEffects` types and default `preprocess` to output type

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,9 +314,11 @@ eg.
 
 ##### Zod Effects
 
-`.transform()` and `.preprocess()` are complicated because they are technically two types (input & output). This means that we need to understand which type you are after. This means if you are adding the ZodSchema directly to the `components` section, we need to know whether you want the response or request type created. You can do this by setting the `refType` field to `input` or `output` in `.openapi()`. This defaults to `output` by default.
+`.transform()` is complicated because it technically comprises of two types (input & output). This means that we need to understand which type you are creating. If you are adding the ZodSchema directly to the `components` section, context is required with knowing to create an input schema or an output schema. You can do this by setting the `refType` field to `input` or `output` in `.openapi()`. This defaults to `output` by default.
 
-If you use a registered schema with a ZodEffect in both a request and response schema you will receive an error because we cannot register two different schemas under the same `ref`.
+`.preprocess()` will always return the `output` type even if we are creating an input schema. If a different input type is required you can achieve this with a `.transform()` combined with a `.pipe()` or simply declare a manual `type` in `.openapi()`.
+
+If a registered schema with a ZodEffect is used in both a request and response schema you will receive an error because the created schema for each will be different. To override the creation type for a specific ZodEffect, add an `.openapi()` field to the ZodEffect and set the `effectType` field to `input` or `output`.
 
 #### Parameters
 
@@ -363,7 +365,7 @@ const header = z.string().openapi({
   - `discriminator` mapping when all schemas in the union contain a `ref`.
 - ZodEffects
   - `transform` support for request schemas. Wrap your transform in a ZodPipeline to enable response schema creation or declare a manual `type` in the `.openapi()` section of that schema.
-  - `pre-process` support for response schemas. Wrap your transform in a ZodPipeline to enable request schema creation or declare a manual `type` in the `.openapi()` section of that schema.
+  - `pre-process` full support.
   - `refine` full support.
 - ZodEnum
 - ZodLiteral

--- a/src/create/schema/index.test.ts
+++ b/src/create/schema/index.test.ts
@@ -219,6 +219,11 @@ const expectedZodUnknown: oas31.SchemaObject = {
   type: 'string',
 };
 
+const zodOverride = z.string().openapi({ type: 'number' });
+const expectedZodOverride: oas31.SchemaObject = {
+  type: 'number',
+};
+
 describe('createSchemaOrRef', () => {
   it.each`
     zodType                      | schema                   | expected
@@ -246,6 +251,7 @@ describe('createSchemaOrRef', () => {
     ${'ZodEffects - Preprocess'} | ${zodPreprocess}         | ${expectedZodPreprocess}
     ${'ZodEffects - Refine'}     | ${zodRefine}             | ${expectedZodRefine}
     ${'unknown'}                 | ${zodUnknown}            | ${expectedZodUnknown}
+    ${'override'}                | ${zodOverride}           | ${expectedZodOverride}
   `('creates an output schema for $zodType', ({ schema, expected }) => {
     expect(createSchemaOrRef(schema, createOutputState())).toStrictEqual(
       expected,
@@ -253,31 +259,32 @@ describe('createSchemaOrRef', () => {
   });
 
   it.each`
-    zodType                     | schema                   | expected
-    ${'ZodArray'}               | ${zodArray}              | ${expectedZodArray}
-    ${'ZodBoolean'}             | ${zodBoolean}            | ${expectedZodBoolean}
-    ${'ZodDate'}                | ${zodDate}               | ${expectedZodDate}
-    ${'ZodDefault'}             | ${zodDefault}            | ${expectedZodDefault}
-    ${'ZodDiscriminatedUnion'}  | ${zodDiscriminatedUnion} | ${expectedZodDiscriminatedUnion}
-    ${'ZodEnum'}                | ${zodEnum}               | ${expectedZodEnum}
-    ${'ZodIntersection'}        | ${zodIntersection}       | ${expectedZodIntersection}
-    ${'ZodLiteral'}             | ${zodLiteral}            | ${expectedZodLiteral}
-    ${'ZodMetadata'}            | ${zodMetadata}           | ${expectedZodMetadata}
-    ${'ZodNativeEnum'}          | ${zodNativeEnum}         | ${expectedZodNativeEnum}
-    ${'ZodNull'}                | ${zodNull}               | ${expectedZodNull}
-    ${'ZodNullable'}            | ${zodNullable}           | ${expectedZodNullable}
-    ${'ZodNumber'}              | ${zodNumber}             | ${expectedZodNumber}
-    ${'ZodObject'}              | ${zodObject}             | ${expectedZodObject}
-    ${'ZodOptional'}            | ${zodOptional}           | ${expectedZodOptional}
-    ${'ZodRecord'}              | ${zodRecord}             | ${expectedZodRecord}
-    ${'ZodString'}              | ${zodString}             | ${expectedZodString}
-    ${'ZodTuple'}               | ${zodTuple}              | ${expectedZodTuple}
-    ${'ZodUnion'}               | ${zodUnion}              | ${expectedZodUnion}
-    ${'ZodCatch'}               | ${zodCatch}              | ${expectedZodCatch}
-    ${'ZodPipeline'}            | ${zodPipeline}           | ${expectedZodPipelineInput}
-    ${'ZodEffects - Transform'} | ${zodTransform}          | ${expectedZodTransform}
-    ${'ZodEffects - Refine'}    | ${zodRefine}             | ${expectedZodRefine}
-    ${'unknown'}                | ${zodUnknown}            | ${expectedZodUnknown}
+    zodType                      | schema                   | expected
+    ${'ZodArray'}                | ${zodArray}              | ${expectedZodArray}
+    ${'ZodBoolean'}              | ${zodBoolean}            | ${expectedZodBoolean}
+    ${'ZodDate'}                 | ${zodDate}               | ${expectedZodDate}
+    ${'ZodDefault'}              | ${zodDefault}            | ${expectedZodDefault}
+    ${'ZodDiscriminatedUnion'}   | ${zodDiscriminatedUnion} | ${expectedZodDiscriminatedUnion}
+    ${'ZodEnum'}                 | ${zodEnum}               | ${expectedZodEnum}
+    ${'ZodIntersection'}         | ${zodIntersection}       | ${expectedZodIntersection}
+    ${'ZodLiteral'}              | ${zodLiteral}            | ${expectedZodLiteral}
+    ${'ZodMetadata'}             | ${zodMetadata}           | ${expectedZodMetadata}
+    ${'ZodNativeEnum'}           | ${zodNativeEnum}         | ${expectedZodNativeEnum}
+    ${'ZodNull'}                 | ${zodNull}               | ${expectedZodNull}
+    ${'ZodNullable'}             | ${zodNullable}           | ${expectedZodNullable}
+    ${'ZodNumber'}               | ${zodNumber}             | ${expectedZodNumber}
+    ${'ZodObject'}               | ${zodObject}             | ${expectedZodObject}
+    ${'ZodOptional'}             | ${zodOptional}           | ${expectedZodOptional}
+    ${'ZodRecord'}               | ${zodRecord}             | ${expectedZodRecord}
+    ${'ZodString'}               | ${zodString}             | ${expectedZodString}
+    ${'ZodTuple'}                | ${zodTuple}              | ${expectedZodTuple}
+    ${'ZodUnion'}                | ${zodUnion}              | ${expectedZodUnion}
+    ${'ZodCatch'}                | ${zodCatch}              | ${expectedZodCatch}
+    ${'ZodPipeline'}             | ${zodPipeline}           | ${expectedZodPipelineInput}
+    ${'ZodEffects - Preprocess'} | ${zodPreprocess}         | ${expectedZodPreprocess}
+    ${'ZodEffects - Transform'}  | ${zodTransform}          | ${expectedZodTransform}
+    ${'ZodEffects - Refine'}     | ${zodRefine}             | ${expectedZodRefine}
+    ${'unknown'}                 | ${zodUnknown}            | ${expectedZodUnknown}
   `('creates an input schema for $zodType', ({ schema, expected }) => {
     expect(createSchemaOrRef(schema, createInputState())).toStrictEqual(
       expected,

--- a/src/create/schema/index.ts
+++ b/src/create/schema/index.ts
@@ -71,6 +71,10 @@ export const createSchema = <
   zodSchema: ZodType<Output, Def, Input>,
   state: SchemaState,
 ): oas31.SchemaObject | oas31.ReferenceObject => {
+  if (zodSchema._def.openapi?.type) {
+    return createUnknownSchema(zodSchema);
+  }
+
   if (zodSchema instanceof ZodString) {
     return createStringSchema(zodSchema);
   }

--- a/src/create/schema/preprocess.test.ts
+++ b/src/create/schema/preprocess.test.ts
@@ -2,71 +2,24 @@ import { oas31 } from 'openapi3-ts';
 import { z } from 'zod';
 
 import { extendZodWithOpenApi } from '../../extendZod';
-import { createInputState, createOutputState } from '../../testing/state';
+import { createOutputState } from '../../testing/state';
 
 import { createPreprocessSchema } from './preprocess';
 
 extendZodWithOpenApi(z);
 
 describe('createPreprocessSchema', () => {
-  describe('input', () => {
-    it('throws an error when creating an input schema with preprocess', () => {
-      const schema = z.preprocess(
-        (arg) => (typeof arg === 'string' ? arg.split(',') : arg),
-        z.string(),
-      );
-      expect(() =>
-        createPreprocessSchema(schema, createInputState()),
-      ).toThrow();
-    });
+  it('returns a schema with preprocess', () => {
+    const expected: oas31.SchemaObject = {
+      type: 'string',
+    };
+    const schema = z.preprocess(
+      (arg) => (typeof arg === 'string' ? arg.split(',') : arg),
+      z.string(),
+    );
 
-    it('returns a manually declared type when creating an input schema with preprocess', () => {
-      const expected: oas31.SchemaObject = {
-        type: 'string',
-      };
-      const schema = z
-        .preprocess(
-          (arg) => (typeof arg === 'string' ? arg.split(',') : arg),
-          z.string(),
-        )
-        .openapi({ type: 'string' });
+    const result = createPreprocessSchema(schema, createOutputState());
 
-      const result = createPreprocessSchema(schema, createInputState());
-
-      expect(result).toStrictEqual(expected);
-    });
-  });
-
-  describe('output', () => {
-    it('returns a schema when creating an output schema with preprocess', () => {
-      const expected: oas31.SchemaObject = {
-        type: 'string',
-      };
-      const schema = z
-        .preprocess(
-          (arg) => (typeof arg === 'string' ? arg.split(',') : arg),
-          z.string(),
-        )
-        .openapi({ type: 'string' });
-
-      const result = createPreprocessSchema(schema, createOutputState());
-
-      expect(result).toStrictEqual(expected);
-    });
-
-    it('changes the state effectType to output', () => {
-      const schema = z
-        .preprocess(
-          (arg) => (typeof arg === 'string' ? arg.split(',') : arg),
-          z.string(),
-        )
-        .openapi({ type: 'string' });
-
-      const state = createOutputState();
-
-      createPreprocessSchema(schema, state);
-
-      expect(state.effectType).toBe('output');
-    });
+    expect(result).toStrictEqual(expected);
   });
 });

--- a/src/create/schema/preprocess.ts
+++ b/src/create/schema/preprocess.ts
@@ -1,18 +1,10 @@
 import { oas31 } from 'openapi3-ts';
 import { ZodEffects, ZodType } from 'zod';
 
-import { createUnknownSchema } from './unknown';
-
 import { SchemaState, createSchemaOrRef } from '.';
 
 export const createPreprocessSchema = (
   zodPreprocess: ZodEffects<any, any, any>,
   state: SchemaState,
-): oas31.SchemaObject | oas31.ReferenceObject => {
-  if (state.type === 'output') {
-    state.effectType = 'output';
-    return createSchemaOrRef(zodPreprocess._def.schema as ZodType, state);
-  }
-
-  return createUnknownSchema(zodPreprocess);
-};
+): oas31.SchemaObject | oas31.ReferenceObject =>
+  createSchemaOrRef(zodPreprocess._def.schema as ZodType, state);

--- a/src/create/schema/transform.test.ts
+++ b/src/create/schema/transform.test.ts
@@ -53,5 +53,32 @@ describe('createTransformSchema', () => {
 
       expect(result).toStrictEqual(expected);
     });
+
+    it('returns a schema when creating a schema with transform when openapi effectType is set', () => {
+      const expected: oas31.SchemaObject = {
+        type: 'string',
+      };
+      const schema = z
+        .string()
+        .transform((str) => str.length)
+        .openapi({ effectType: 'input' });
+
+      const result = createTransformSchema(schema, createOutputState());
+
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('does not change the state effectType when openapi effectType is set', () => {
+      const schema = z
+        .string()
+        .transform((str) => str.length)
+        .openapi({ effectType: 'input' });
+
+      const state = createOutputState();
+
+      createTransformSchema(schema, state);
+
+      expect(state.effectType).toBeUndefined();
+    });
   });
 });

--- a/src/create/schema/transform.ts
+++ b/src/create/schema/transform.ts
@@ -9,8 +9,11 @@ export const createTransformSchema = (
   zodTransform: ZodEffects<any, any, any>,
   state: SchemaState,
 ): oas31.SchemaObject | oas31.ReferenceObject => {
-  if (state.type === 'input') {
-    state.effectType = 'input';
+  const creationType = zodTransform._def.openapi?.effectType ?? state.type;
+  if (creationType === 'input') {
+    if (state.type === 'input') {
+      state.effectType = 'input';
+    }
     return createSchemaOrRef(zodTransform._def.schema as ZodType, state);
   }
 

--- a/src/extendZod.ts
+++ b/src/extendZod.ts
@@ -25,6 +25,10 @@ interface ZodOpenApiMetadata<T extends ZodTypeAny, TInferred = z.infer<T>>
    * Use this field when you are manually adding a Zod Schema to the components section. This controls whether this should be rendered as request (`input`) or response (`output`). Defaults to `output`
    */
   refType?: CreationType;
+  /**
+   * Use this field to set the created type of an effect.
+   */
+  effectType?: CreationType;
   param?: Partial<oas31.ParameterObject> & {
     example?: TInferred;
     examples?: {


### PR DESCRIPTION
This allows users to override the creation type of a ZodEffect. Sometimes users may not change the type very much.

```ts
z.string().transform((arg) => arg.toLowerCase())
```

 In this case the type remains a string. However, our library does not know that.

A user can either wrap it in a ZodPipeline and parse it again or they can tell our library to trust that the type has not changed.

```ts
z.string()
.transform((arg) => arg.toLowerCase())
.pipe(z.string())
```

or you can set the 
```ts
z.string()
.transform((arg) => arg.toLowerCase())
.openapi({effectType: 'input'})
```

or you can say "trust me"
```ts
z.string()
.transform((arg) => arg.toLowerCase())
.openapi({type: 'string'})
```