### PR TITLE
Unpin `openapi3-ts` and `yaml` versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "test:watch": "skuba test --watch"
   },
   "dependencies": {
-    "openapi3-ts": "4.1.2",
-    "yaml": "2.2.2"
+    "openapi3-ts": "^4.1.2",
+    "yaml": "^2.2.2"
   },
   "devDependencies": {
     "@redocly/cli": "1.0.0-beta.125",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5973,7 +5973,7 @@ openapi-sampler@^1.3.0:
     "@types/json-schema" "^7.0.7"
     json-pointer "0.6.2"
 
-openapi3-ts@4.1.2:
+openapi3-ts@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/openapi3-ts/-/openapi3-ts-4.1.2.tgz#f15cd4794e3a7c9b388fd45dfbefc78501f7043e"
   integrity sha512-B7gOkwsYMZO7BZXwJzXCuVagym2xhqsrilVvV0dnq2Di4+iLUXKVX9gOK23ZqaAHZOwABXN0QTdW8QnkUTX6DA==
@@ -7959,15 +7959,15 @@ yaml-eslint-parser@^1.1.0:
     lodash "^4.17.21"
     yaml "^2.0.0"
 
-yaml@2.2.2, yaml@^2.0.0, yaml@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
-  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
-
 yaml@^1.10.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yaml@^2.0.0, yaml@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
+  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
 
 yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.9"


### PR DESCRIPTION
This will allow consumers to re-lock to fix issues going forward