### PR TITLE
Use `headers` key for response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ If you wish to use OpenAPI syntax for your schemas, simply add an OpenAPI schema
 
 ### Responses
 
-Similarly to the [Request Body](#request-body), simply set the `schema` as your Zod Schema as follows. You can set the response headers using the `responseHeaders` key.
+Similarly to the [Request Body](#request-body), simply set the `schema` as your Zod Schema as follows. You can set the response headers using the `headers` key.
 
 ```typescript
 createDocument({
@@ -220,7 +220,7 @@ createDocument({
             content: {
               'application/json': { schema: z.object({ a: z.string() }) },
             },
-            responseHeaders: z.object({
+            headers: z.object({
               'header-key': z.string(),
             }),
           },
@@ -353,7 +353,7 @@ const jobIdHeader = z.string().openapi({
 
 createDocument({
   components: {
-    responseHeaders: z.object(
+    headers: z.object(
       'some-header': jobIdHeader
     )
   },

--- a/src/create/components.test.ts
+++ b/src/create/components.test.ts
@@ -80,14 +80,7 @@ describe('getDefaultComponents', () => {
           type: 'string',
         },
       },
-      headers: {
-        a: {
-          schema: {
-            type: 'string',
-          },
-        },
-      },
-      responseHeaders: z.object({
+      headers: z.object({
         c: cSchema,
       }),
       responses: {

--- a/src/create/components.ts
+++ b/src/create/components.ts
@@ -163,7 +163,7 @@ export const getDefaultComponents = (
   createSchemas(componentsObject.schemas, defaultComponents);
   createParameters(componentsObject.requestParams, defaultComponents);
   createRequestBodies(componentsObject.requestBodies, defaultComponents);
-  createHeaders(componentsObject.responseHeaders, defaultComponents);
+  createHeaders(componentsObject.headers, defaultComponents);
   createResponses(componentsObject.responses, defaultComponents);
 
   return defaultComponents;
@@ -240,10 +240,14 @@ const createParameters = (
 };
 
 const createHeaders = (
-  responseHeaders: ZodOpenApiComponentsObject['responseHeaders'],
+  responseHeaders: ZodOpenApiComponentsObject['headers'],
   components: ComponentsObject,
 ): void => {
   if (!responseHeaders) {
+    return;
+  }
+
+  if (!(responseHeaders instanceof ZodType)) {
     return;
   }
 
@@ -445,19 +449,20 @@ const createHeaderComponents = (
   componentsObject: ZodOpenApiComponentsObject,
   componentMap: HeaderComponentMap,
 ): oas31.ComponentsObject['headers'] => {
-  const customComponents = Object.entries(
-    componentsObject.headers ?? {},
-  ).reduce<NonNullable<oas31.ComponentsObject['headers']>>(
-    (acc, [key, value]) => {
-      if (acc[key]) {
-        throw new Error(`Header "${key}" is already registered`);
-      }
+  const headers = componentsObject.headers ?? {};
+  const customComponents =
+    headers instanceof ZodType
+      ? {}
+      : Object.entries(headers).reduce<
+          NonNullable<oas31.ComponentsObject['headers']>
+        >((acc, [key, value]) => {
+          if (acc[key]) {
+            throw new Error(`Header "${key}" is already registered`);
+          }
 
-      acc[key] = value as oas31.HeaderObject;
-      return acc;
-    },
-    {},
-  );
+          acc[key] = value as oas31.HeaderObject;
+          return acc;
+        }, {});
 
   const components = Array.from(componentMap).reduce<
     NonNullable<oas31.ComponentsObject['headers']>

--- a/src/create/document.test.ts
+++ b/src/create/document.test.ts
@@ -77,7 +77,7 @@ const registeredZodOpenApiObject: ZodOpenApiObject = {
                 schema: registered,
               },
             },
-            responseHeaders: z.object({
+            headers: z.object({
               'my-header': z.string().openapi({ header: { ref: 'my-header' } }),
             }),
           },
@@ -131,7 +131,7 @@ const complexZodOpenApiObject: ZodOpenApiObject = {
                 schema: complex,
               },
             },
-            responseHeaders: z.object({
+            headers: z.object({
               'my-header': z.string().openapi({ header: { ref: 'my-header' } }),
             }),
           },

--- a/src/create/document.ts
+++ b/src/create/document.ts
@@ -24,9 +24,12 @@ export interface ZodOpenApiRequestBodyObject
 }
 
 export interface ZodOpenApiResponseObject
-  extends Omit<oas31.ResponseObject & oas30.ResponseObject, 'content'> {
+  extends Omit<
+    oas31.ResponseObject & oas30.ResponseObject,
+    'content' | 'headers'
+  > {
   content?: ZodOpenApiContentObject;
-  responseHeaders?: AnyZodObject;
+  headers?: AnyZodObject | oas30.HeadersObject | oas31.HeadersObject;
   /** Use this field to auto register this response object as a component */
   ref?: string;
 }
@@ -78,7 +81,7 @@ export interface ZodOpenApiPathsObject extends oas31.ISpecificationExtension {
 export interface ZodOpenApiComponentsObject
   extends Omit<
     oas31.ComponentsObject & oas30.ComponentsObject,
-    'schemas' | 'responses' | 'requestBodies'
+    'schemas' | 'responses' | 'requestBodies' | 'headers'
   > {
   schemas?: {
     [ref: string]:
@@ -92,7 +95,7 @@ export interface ZodOpenApiComponentsObject
     [ref: string]: ZodOpenApiRequestBodyObject;
   };
   requestParams?: ZodOpenApiParameters;
-  responseHeaders?: AnyZodObject;
+  headers?: AnyZodObject | oas31.HeadersObject | oas30.HeadersObject;
   responses?: {
     [ref: string]: ZodOpenApiResponseObject;
   };

--- a/src/create/responses.test.ts
+++ b/src/create/responses.test.ts
@@ -42,14 +42,7 @@ describe('createResponses', () => {
               schema: z.object({ a: z.string() }),
             },
           },
-          headers: {
-            a: {
-              schema: {
-                type: 'string',
-              },
-            },
-          },
-          responseHeaders: z.object({
+          headers: z.object({
             a: z.string().openapi({ header: { ref: 'a' } }),
           }),
         },


### PR DESCRIPTION
Uses the `headers` response key instead of `responseHeaders`. This was a mistake on my behalf.

I haven't advertised this library anywhere big yet intentionally so I'm going to go with minor change for now.