### PR TITLE
Add ZodObject .catchall() support

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ For example in `z.string().nullable()` will be rendered differently
   - `integer` `type` mapping for `.int()`
   - `exclusiveMin`/`min`/`exclusiveMax`/`max` mapping for `.min()`, `.max()`, `lt()`, `gt()`
 - ZodObject
+  - `additionalProperties` mapping for `.catchall()`, `.strict()`
 - ZodOptional
 - ZodPipeline
 - ZodRecord

--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ For example in `z.string().nullable()` will be rendered differently
   - `exclusiveMin`/`min`/`exclusiveMax`/`max` mapping for `.min()`, `.max()`, `lt()`, `gt()`
 - ZodObject
   - `additionalProperties` mapping for `.catchall()`, `.strict()`
+  - `allOf` mapping for `.extend()` when the base object is registered and does not have `catchall()`, `strict()` and extension does not override a field.
 - ZodOptional
 - ZodPipeline
 - ZodRecord

--- a/src/create/schema/object.test.ts
+++ b/src/create/schema/object.test.ts
@@ -77,4 +77,28 @@ describe('createObjectSchema', () => {
 
     expect(result).toStrictEqual(expected);
   });
+
+  it('supports catchall', () => {
+    const expected: oas31.SchemaObject = {
+      type: 'object',
+      properties: {
+        a: {
+          type: 'string',
+        },
+      },
+      required: ['a'],
+      additionalProperties: {
+        type: 'boolean',
+      },
+    };
+    const schema = z
+      .object({
+        a: z.string(),
+      })
+      .catchall(z.boolean());
+
+    const result = createObjectSchema(schema, createOutputState());
+
+    expect(result).toStrictEqual(expected);
+  });
 });

--- a/src/create/schema/object.ts
+++ b/src/create/schema/object.ts
@@ -130,7 +130,7 @@ const createShapeDiff = (
 
 interface AdditionalPropertyOptions {
   unknownKeys?: UnknownKeysParam;
-  catchAll?: ZodType;
+  catchAll: ZodType;
 }
 
 export const createObjectSchemaFromShape = (
@@ -142,10 +142,9 @@ export const createObjectSchemaFromShape = (
   properties: mapProperties(shape, state),
   required: mapRequired(shape),
   ...(unknownKeys === 'strict' && { additionalProperties: false }),
-  ...(catchAll &&
-    !(catchAll instanceof ZodNever) && {
-      additionalProperties: createSchemaOrRef(catchAll, state),
-    }),
+  ...(!(catchAll instanceof ZodNever) && {
+    additionalProperties: createSchemaOrRef(catchAll, state),
+  }),
 });
 
 export const mapRequired = (


### PR DESCRIPTION
Adds `catchAll` additionalProperties mapping for ZodObjects