### PR TITLE
Do not create allOf schema when extend overrides a field

### DIFF
--- a/src/extendZod.test.ts
+++ b/src/extendZod.test.ts
@@ -34,7 +34,6 @@ describe('extendZodWithOpenApi', () => {
 
     expect(a._def.openapi?.ref).toBe('a');
     expect(b._def.extendMetadata?.extends).toStrictEqual(a);
-    expect(b._def.extendMetadata?.extendsRef).toBe('a');
   });
 
   it('adds removes extendsMetadata to an object when .omit or .pick is used', () => {
@@ -45,7 +44,6 @@ describe('extendZodWithOpenApi', () => {
 
     expect(a._def.openapi?.ref).toBe('a');
     expect(b._def.extendMetadata?.extends).toStrictEqual(a);
-    expect(b._def.extendMetadata?.extendsRef).toBe('a');
     expect(c._def.extendMetadata).toBeUndefined();
     expect(c._def.openapi).toBeUndefined();
     expect(d._def.extendMetadata).toBeUndefined();

--- a/src/extendZod.ts
+++ b/src/extendZod.ts
@@ -51,8 +51,6 @@ interface ZodOpenApiMetadata<T extends ZodTypeAny, TInferred = z.infer<T>>
 
 interface ZodOpenApiExtendMetadata {
   extends: ZodObject<any, any, any, any, any>;
-
-  extendsRef?: string;
 }
 
 declare module 'zod' {
@@ -101,7 +99,6 @@ export function extendZodWithOpenApi(zod: typeof z) {
     const extendResult = zodObjectExtend.apply(this, args);
     extendResult._def.extendMetadata = {
       extends: this,
-      extendsRef: extendResult._def.openapi?.ref,
     };
     delete extendResult._def.openapi;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return


### PR DESCRIPTION
Partially resolves https://github.com/samchungy/zod-openapi/issues/57
Fixes the extend logic to not create an allOf when an .extend overrides a field. It is too hard to calculate if the new type (String checks, number checks etc) is derivative of an existing type. Additionally, Zod does not care about the base field meaning even if we were to add an `allOf` it would not match the Zod behaviour.

https://json-schema.org/understanding-json-schema/reference/combining.html#allof