### PR TITLE
Fix manual parameter components

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,26 @@ createDocument({
 });
 ```
 
-If you would like to declare parameters using OpenAPI syntax you may also declare them using the [parameters](https://swagger.io/docs/specification/describing-parameters/) key. The definitions will then all be combined.
+If you would like to declare parameters in a more traditional way you may also declare them using the [parameters](https://swagger.io/docs/specification/describing-parameters/) key. The definitions will then all be combined.
+
+```ts
+createDocument({
+  paths: {
+    '/jobs/:a': {
+      put: {
+        parameters: [
+          z.string().openapi({
+            param: {
+              name: 'job-header',
+              in: 'header',
+            },
+          }),
+        ],
+      },
+    },
+  },
+});
+```
 
 ### Request Body
 
@@ -307,27 +326,55 @@ If a registered schema with a transform is used in both a request and response s
 Query, Path, Header & Cookie parameters can be similarly registered:
 
 ```typescript
+// Easy auto registration
 const jobId = z.string().openapi({
   description: 'Job ID',
   example: '1234',
-  param: { ref: 'jobId' },
+  param: { ref: 'jobRef' },
 });
 
-// or
-
-const commonHeaders = z.object({
-  jobId: z.string(),
+createDocument({
+  paths: {
+    '/jobs/{jobId}': {
+      put: {
+        requestParams: {
+          header: z.object({
+            jobId,
+          }),
+        },
+      },
+    },
+  },
 });
 
-const path = z.string();
+// or more verbose auto registration
+const jobId = z.string().openapi({
+  description: 'Job ID',
+  example: '1234',
+  param: { in: 'header', name: 'jobId', ref: 'jobRef' },
+});
+
+createDocument({
+  paths: {
+    '/jobs/{jobId}': {
+      put: {
+        parameters: [jobId],
+      },
+    },
+  },
+});
+
+// or manual registeration
+const otherJobId = z.string().openapi({
+  description: 'Job ID',
+  example: '1234',
+  param: { in: 'header', name: 'jobId' },
+});
 
 createDocument({
   components: {
-    requestParams: {
-      header: commonHeaders,
-      path: z.object({ path }),
-      query: z.object({ query: z.string() }),
-      cookie: z.object({ cookie: z.string() }),
+    parameters: {
+      jobRef: jobId,
     },
   },
 });

--- a/src/create/components.test.ts
+++ b/src/create/components.test.ts
@@ -42,7 +42,7 @@ describe('getDefaultComponents', () => {
 
   it('returns components combined with manually declared components', () => {
     const aSchema = z.string();
-    const bSchema = z.string();
+    const bSchema = z.string().openapi({ param: { in: 'header', name: 'b' } });
     const cSchema = z.string();
     const dResponse: ZodOpenApiResponseObject = {
       description: '200 OK',
@@ -68,11 +68,7 @@ describe('getDefaultComponents', () => {
             type: 'string',
           },
         },
-      },
-      requestParams: {
-        header: z.object({
-          b: bSchema,
-        }),
+        b: bSchema,
       },
       schemas: {
         a: aSchema,
@@ -107,6 +103,8 @@ describe('getDefaultComponents', () => {
       },
       ref: 'b',
       type: 'complete',
+      in: 'header',
+      name: 'b',
     };
     const expectedSchema: SchemaComponent = {
       schemaObject: {
@@ -316,6 +314,8 @@ describe('createComponents', () => {
           type: 'string',
         },
       },
+      in: 'header',
+      name: 'some-header',
     });
     const headerMap: HeaderComponentMap = new Map();
     headerMap.set(z.string(), {
@@ -451,6 +451,8 @@ describe('createComponents', () => {
         },
       },
       ref: 'a',
+      in: 'header',
+      name: 'some-header',
     });
     const headerMap: HeaderComponentMap = new Map();
     headerMap.set(z.string(), {

--- a/src/create/document.ts
+++ b/src/create/document.ts
@@ -52,8 +52,15 @@ export type ZodOpenApiParameters = {
 export interface ZodOpenApiOperationObject
   extends Omit<
     oas31.OperationObject & oas30.OperationObject,
-    'requestBody' | 'responses'
+    'requestBody' | 'responses' | 'parameters'
   > {
+  parameters?: (
+    | ZodType
+    | oas31.ParameterObject
+    | oas30.ParameterObject
+    | oas31.ReferenceObject
+    | oas30.ReferenceObject
+  )[];
   requestBody?: ZodOpenApiRequestBodyObject;
   requestParams?: ZodOpenApiParameters;
   responses: ZodOpenApiResponsesObject;
@@ -81,8 +88,16 @@ export interface ZodOpenApiPathsObject extends oas31.ISpecificationExtension {
 export interface ZodOpenApiComponentsObject
   extends Omit<
     oas31.ComponentsObject & oas30.ComponentsObject,
-    'schemas' | 'responses' | 'requestBodies' | 'headers'
+    'schemas' | 'responses' | 'requestBodies' | 'headers' | 'parameters'
   > {
+  parameters?: {
+    [parameter: string]:
+      | ZodType
+      | oas31.ParameterObject
+      | oas30.ParameterObject
+      | oas31.ReferenceObject
+      | oas30.ReferenceObject;
+  };
   schemas?: {
     [ref: string]:
       | ZodType
@@ -94,7 +109,6 @@ export interface ZodOpenApiComponentsObject
   requestBodies?: {
     [ref: string]: ZodOpenApiRequestBodyObject;
   };
-  requestParams?: ZodOpenApiParameters;
   headers?: AnyZodObject | oas31.HeadersObject | oas30.HeadersObject;
   responses?: {
     [ref: string]: ZodOpenApiResponseObject;

--- a/src/create/parameters.test.ts
+++ b/src/create/parameters.test.ts
@@ -37,6 +37,26 @@ describe('createBaseParameter', () => {
 });
 
 describe('createParametersObject', () => {
+  it('should create a parameters object using parameters', () => {
+    const expectedResult: oas31.OperationObject['parameters'] = [
+      {
+        in: 'header',
+        name: 'd',
+        schema: {
+          type: 'string',
+        },
+        required: true,
+      },
+    ];
+    const result = createParametersObject(
+      [z.string().openapi({ param: { in: 'header', name: 'd' } })],
+      {},
+      getDefaultComponents(),
+    );
+
+    expect(result).toStrictEqual(expectedResult);
+  });
+
   it('should create a parameters object using requestParams', () => {
     const expectedResult: oas31.OperationObject['parameters'] = [
       {
@@ -180,6 +200,21 @@ describe('createParametersObject', () => {
         cookie: z.object({ c: z.string().openapi({ param: { ref: 'c' } }) }),
         header: z.object({ d: z.string().openapi({ param: { ref: 'd' } }) }),
       },
+      getDefaultComponents(),
+    );
+
+    expect(result).toStrictEqual(expectedResult);
+  });
+
+  it('should create refs using parameters', () => {
+    const expectedResult: oas31.OperationObject['parameters'] = [
+      {
+        $ref: '#/components/parameters/a',
+      },
+    ];
+    const result = createParametersObject(
+      [z.string().openapi({ param: { ref: 'a', name: 'a', in: 'header' } })],
+      {},
       getDefaultComponents(),
     );
 


### PR DESCRIPTION
Technically another breaking change - but no one has complained yet so I will assume nobody is using this right now.

Having `requestParams` on the components doesn't make sense as it confuses and right now uses the name as the ref.

This adds another way to register parameters.