### PR TITLE
Enhance extend allOf behaviour

### DIFF
--- a/src/create/document.test.ts
+++ b/src/create/document.test.ts
@@ -354,21 +354,19 @@ describe('createDocument', () => {
                 {
                   "$ref": "#/components/schemas/b",
                 },
-                {
-                  "properties": {
-                    "d": {
-                      "type": [
-                        "string",
-                        "null",
-                      ],
-                    },
-                  },
-                  "required": [
-                    "d",
-                  ],
-                  "type": "object",
-                },
               ],
+              "properties": {
+                "d": {
+                  "type": [
+                    "string",
+                    "null",
+                  ],
+                },
+              },
+              "required": [
+                "d",
+              ],
+              "type": "object",
             },
             "lazy": {
               "items": {
@@ -618,19 +616,17 @@ describe('createDocument', () => {
                 {
                   "$ref": "#/components/schemas/b",
                 },
-                {
-                  "properties": {
-                    "d": {
-                      "nullable": true,
-                      "type": "string",
-                    },
-                  },
-                  "required": [
-                    "d",
-                  ],
-                  "type": "object",
-                },
               ],
+              "properties": {
+                "d": {
+                  "nullable": true,
+                  "type": "string",
+                },
+              },
+              "required": [
+                "d",
+              ],
+              "type": "object",
             },
             "lazy": {
               "items": {

--- a/src/create/schema/metadata.test.ts
+++ b/src/create/schema/metadata.test.ts
@@ -110,15 +110,11 @@ describe('createSchemaWithMetadata', () => {
       type: 'object',
       properties: {
         b: {
-          allOf: [
-            { $ref: '#/components/schemas/a' },
-            {
-              type: 'object',
-              properties: { b: { type: 'string' } },
-              required: ['b'],
-              description: 'jello',
-            },
-          ],
+          allOf: [{ $ref: '#/components/schemas/a' }],
+          type: 'object',
+          properties: { b: { type: 'string' } },
+          required: ['b'],
+          description: 'jello',
         },
       },
       required: ['b'],

--- a/src/create/schema/metadata.ts
+++ b/src/create/schema/metadata.ts
@@ -37,15 +37,6 @@ export const enhanceWithMetadata = (
     };
   }
 
-  if (schemaOrRef.allOf) {
-    const rest = schemaOrRef.allOf.slice(0, -1);
-    const end = schemaOrRef.allOf.at(-1);
-    return {
-      ...schemaOrRef,
-      allOf: [...rest, ...(end ? [enhanceWithMetadata(end, metadata)] : [])],
-    };
-  }
-
   return {
     ...schemaOrRef,
     ...metadata,

--- a/src/create/schema/nullable.test.ts
+++ b/src/create/schema/nullable.test.ts
@@ -86,14 +86,10 @@ describe('createNullableSchema', () => {
           b: {
             oneOf: [
               {
-                allOf: [
-                  { $ref: '#/components/schemas/a' },
-                  {
-                    type: 'object',
-                    properties: { b: { type: 'string' } },
-                    required: ['b'],
-                  },
-                ],
+                allOf: [{ $ref: '#/components/schemas/a' }],
+                type: 'object',
+                properties: { b: { type: 'string' } },
+                required: ['b'],
               },
               { nullable: true },
             ],
@@ -198,14 +194,10 @@ describe('createNullableSchema', () => {
           b: {
             oneOf: [
               {
-                allOf: [
-                  { $ref: '#/components/schemas/a' },
-                  {
-                    type: 'object',
-                    properties: { b: { type: 'string' } },
-                    required: ['b'],
-                  },
-                ],
+                allOf: [{ $ref: '#/components/schemas/a' }],
+                type: 'object',
+                properties: { b: { type: 'string' } },
+                required: ['b'],
               },
               { type: 'null' },
             ],

--- a/src/create/schema/object.test.ts
+++ b/src/create/schema/object.test.ts
@@ -80,14 +80,10 @@ describe('extend', () => {
       properties: {
         obj1: { $ref: '#/components/schemas/obj1' },
         obj2: {
-          allOf: [
-            { $ref: '#/components/schemas/obj1' },
-            {
-              type: 'object',
-              properties: { b: { type: 'string' } },
-              required: ['b'],
-            },
-          ],
+          allOf: [{ $ref: '#/components/schemas/obj1' }],
+          type: 'object',
+          properties: { b: { type: 'string' } },
+          required: ['b'],
         },
       },
       required: ['obj1', 'obj2'],
@@ -141,17 +137,13 @@ describe('extend', () => {
       properties: {
         obj1: { $ref: '#/components/schemas/obj1' },
         obj2: {
-          allOf: [
-            { $ref: '#/components/schemas/obj1' },
-            {
-              type: 'object',
-              properties: { b: { type: 'number' } },
-              required: ['b'],
-              additionalProperties: {
-                type: 'boolean',
-              },
-            },
-          ],
+          allOf: [{ $ref: '#/components/schemas/obj1' }],
+          type: 'object',
+          properties: { b: { type: 'number' } },
+          required: ['b'],
+          additionalProperties: {
+            type: 'boolean',
+          },
         },
       },
       required: ['obj1', 'obj2'],

--- a/src/create/schema/object.ts
+++ b/src/create/schema/object.ts
@@ -81,10 +81,8 @@ export const createExtendedSchema = (
   }
 
   return {
-    allOf: [
-      { $ref: createComponentSchemaRef(completeComponent.ref) },
-      createObjectSchemaFromShape(diffShape, diffOpts, state),
-    ],
+    allOf: [{ $ref: createComponentSchemaRef(completeComponent.ref) }],
+    ...createObjectSchemaFromShape(diffShape, diffOpts, state),
   };
 };
 


### PR DESCRIPTION
At the moment if you make an extended schema strict, it will generate an incorrect schema.

https://json-schema.org/understanding-json-schema/reference/object.html#id6

This changes the behaviour from:
```ts
{
  allOf: [
    schema1,
    { additionalProperties: false }
  ]
}
```

to 

```ts
{
  allOf: [
    schema1,
  ],
  additionalProperties: false
}

```