### PR TITLE
Allow schema wrapped by lazy to carry ref instead of lazy itself

### DIFF
--- a/src/create/schema/lazy.ts
+++ b/src/create/schema/lazy.ts
@@ -9,7 +9,7 @@ export const createLazySchema = (
   zodLazy: ZodLazy<any>,
   state: SchemaState,
 ): oas31.ReferenceObject | oas31.SchemaObject => {
-  const component = state.components.schemas.get(zodLazy);
+  const component = state.components.schemas.get(zodLazy) ?? state.components.schemas.get(zodLazy.schema);
   const ref = component?.ref ?? zodLazy._def.openapi?.ref;
   if (!ref) {
     throw new Error(`Please register the ${JSON.stringify(zodLazy._def)} type`);


### PR DESCRIPTION
When doing `foo: z.lazy(() => User)`, where `const User = z.object({}).openapi({ref: 'User'})`, I was getting an error that it didn't recognize typeName: ZodLazy.  This fixed that. 

Leaving the code as I have it here should allow you to do `z.lazy(() => User).openapi({ref: 'User'})`, but I'm not sure if that's desirable/needed; if not, the part before the `??` could be removed.

Thanks for making this library!