### PR TITLE
Export additional elements as api

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ npm install zod zod-openapi
 yarn add zod zod-openapi
 ```
 
-## API
+## Usage
 
 ### `extendZodWithOpenApi`
 
-Mutates Zod with an `.openapi()` method and extra metadata. Make a side-effectful import at the top of your entry point(s).
+This mutates Zod to add an extra `.openapi()` method. Make a side-effectful import at the top of your entry point(s).
 
 ```typescript
 import { z } from 'zod';
@@ -159,8 +159,6 @@ Generates the following object:
   }
 }
 ```
-
-## Usage
 
 ### Request Parameters
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,6 @@
+export {
+  getDefaultComponents,
+  type ComponentsObject,
+} from './create/components';
+export { createMediaTypeSchema } from './create/content';
+export { createParamOrRef } from './create/parameters';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,4 @@
 export * from './create/document';
 export * from './extendZod';
 export * from './openapi3-ts/dist';
-
-export {
-  getDefaultComponents,
-  type ComponentsObject,
-} from './create/components';
-export { createMediaTypeSchema } from './create/content';
-export { createParamOrRef } from './create/parameters';
+export * as api from './api';


### PR DESCRIPTION
To make the usage clearer, hide all of these extra methods under the `api` alias