### PR TITLE
Avoid instanceof checks and rely on typeName

### DIFF
--- a/src/create/components.ts
+++ b/src/create/components.ts
@@ -1,6 +1,7 @@
-import { ZodType } from 'zod';
+import type { ZodType } from 'zod';
 
 import type { oas30, oas31 } from '../openapi3-ts/dist';
+import { isAnyZodType } from '../zodType';
 
 import type {
   ZodOpenApiComponentsObject,
@@ -189,7 +190,7 @@ const getSchemas = (
   }
 
   Object.entries(schemas).forEach(([key, schema]) => {
-    if (schema instanceof ZodType) {
+    if (isAnyZodType(schema)) {
       if (components.schemas.has(schema)) {
         throw new Error(
           `Schema ${JSON.stringify(schema._def)} is already registered`,
@@ -213,7 +214,7 @@ const getParameters = (
   }
 
   Object.entries(parameters).forEach(([key, schema]) => {
-    if (schema instanceof ZodType) {
+    if (isAnyZodType(schema)) {
       if (components.parameters.has(schema)) {
         throw new Error(
           `Parameter ${JSON.stringify(schema._def)} is already registered`,
@@ -245,7 +246,7 @@ const getHeaders = (
   }
 
   Object.entries(responseHeaders).forEach(([key, schema]) => {
-    if (schema instanceof ZodType) {
+    if (isAnyZodType(schema)) {
       if (components.parameters.has(schema)) {
         throw new Error(
           `Header ${JSON.stringify(schema._def)} is already registered`,
@@ -361,7 +362,7 @@ const createSchemaComponents = (
     componentsObject.schemas ?? {},
   ).reduce<NonNullable<oas31.ComponentsObject['schemas']>>(
     (acc, [key, value]) => {
-      if (value instanceof ZodType) {
+      if (isAnyZodType(value)) {
         return acc;
       }
 
@@ -411,7 +412,7 @@ const createParamComponents = (
     componentsObject.parameters ?? {},
   ).reduce<NonNullable<oas31.ComponentsObject['parameters']>>(
     (acc, [key, value]) => {
-      if (!(value instanceof ZodType)) {
+      if (!isAnyZodType(value)) {
         if (acc[key]) {
           throw new Error(`Parameter "${key}" is already registered`);
         }
@@ -453,7 +454,7 @@ const createHeaderComponents = (
   const customComponents = Object.entries(headers).reduce<
     NonNullable<oas31.ComponentsObject['headers']>
   >((acc, [key, value]) => {
-    if (!(value instanceof ZodType)) {
+    if (!isAnyZodType(value)) {
       if (acc[key]) {
         throw new Error(`Header Ref "${key}" is already registered`);
       }

--- a/src/create/content.ts
+++ b/src/create/content.ts
@@ -1,6 +1,7 @@
-import { ZodType } from 'zod';
+import type { ZodType } from 'zod';
 
 import type { oas31 } from '../openapi3-ts/dist';
+import { isAnyZodType } from '../zodType';
 
 import type { ComponentsObject, CreationType } from './components';
 import type {
@@ -23,7 +24,7 @@ export const createMediaTypeSchema = (
     return undefined;
   }
 
-  if (!(schemaObject instanceof ZodType)) {
+  if (!isAnyZodType(schemaObject)) {
     return schemaObject;
   }
 

--- a/src/create/parameters.ts
+++ b/src/create/parameters.ts
@@ -1,7 +1,7 @@
-import { ZodType } from 'zod';
-import type { AnyZodObject, ZodRawShape } from 'zod';
+import type { AnyZodObject, ZodRawShape, ZodType } from 'zod';
 
 import type { oas30, oas31 } from '../openapi3-ts/dist';
+import { isAnyZodType } from '../zodType';
 
 import type { ComponentsObject } from './components';
 import type { ZodOpenApiParameters } from './document';
@@ -163,7 +163,7 @@ export const createManualParameters = (
   subpath: string[],
 ): (oas31.ParameterObject | oas31.ReferenceObject)[] =>
   parameters?.map((param, index) => {
-    if (param instanceof ZodType) {
+    if (isAnyZodType(param)) {
       return createParamOrRef(param, components, [
         ...subpath,
         `param index ${index}`,

--- a/src/create/responses.ts
+++ b/src/create/responses.ts
@@ -1,6 +1,7 @@
-import { type AnyZodObject, type ZodRawShape, ZodType } from 'zod';
+import type { AnyZodObject, ZodRawShape, ZodType } from 'zod';
 
 import type { oas30, oas31 } from '../openapi3-ts/dist';
+import { isAnyZodType } from '../zodType';
 
 import {
   type ComponentsObject,
@@ -27,7 +28,7 @@ export const createResponseHeaders = (
     return undefined;
   }
 
-  if (responseHeaders instanceof ZodType) {
+  if (isAnyZodType(responseHeaders)) {
     return Object.entries(responseHeaders.shape as ZodRawShape).reduce<
       NonNullable<oas31.ResponseObject['headers']>
     >((acc, [key, zodSchema]: [string, ZodType]) => {

--- a/src/create/schema/parsers/discriminatedUnion.ts
+++ b/src/create/schema/parsers/discriminatedUnion.ts
@@ -1,12 +1,12 @@
-import {
-  type AnyZodObject,
-  type ZodDiscriminatedUnion,
-  ZodEnum,
-  type ZodLiteralDef,
-  type ZodRawShape,
+import type {
+  AnyZodObject,
+  ZodDiscriminatedUnion,
+  ZodLiteralDef,
+  ZodRawShape,
 } from 'zod';
 
 import type { oas31 } from '../../../openapi3-ts/dist';
+import { isZodType } from '../../../zodType';
 import { type SchemaState, createSchemaObject } from '../../schema';
 
 export const createDiscriminatedUnionSchema = (
@@ -49,7 +49,7 @@ export const mapDiscriminator = (
 
     const value = (zodObject.shape as ZodRawShape)[discriminator];
 
-    if (value instanceof ZodEnum) {
+    if (isZodType(value, 'ZodEnum')) {
       for (const enumValue of value._def.values as string[]) {
         mapping[enumValue] = componentSchemaRef;
       }

--- a/src/create/schema/parsers/index.ts
+++ b/src/create/schema/parsers/index.ts
@@ -1,35 +1,7 @@
-import {
-  ZodAny,
-  ZodArray,
-  ZodBoolean,
-  ZodBranded,
-  ZodCatch,
-  ZodDate,
-  ZodDefault,
-  ZodDiscriminatedUnion,
-  ZodEffects,
-  ZodEnum,
-  ZodIntersection,
-  ZodLazy,
-  ZodLiteral,
-  ZodNativeEnum,
-  ZodNull,
-  ZodNullable,
-  ZodNumber,
-  ZodObject,
-  ZodOptional,
-  ZodPipeline,
-  ZodRecord,
-  ZodSet,
-  ZodString,
-  ZodTuple,
-  type ZodType,
-  type ZodTypeDef,
-  ZodUnion,
-  ZodUnknown,
-} from 'zod';
+import type { ZodType, ZodTypeDef } from 'zod';
 
 import type { oas31 } from '../../../openapi3-ts/dist';
+import { isZodType } from '../../../zodType';
 import type { SchemaState } from '../../schema';
 
 import { createArraySchema } from './array';
@@ -73,124 +45,124 @@ export const createSchemaSwitch = <
     return createManualTypeSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodString) {
+  if (isZodType(zodSchema, 'ZodString')) {
     return createStringSchema(zodSchema);
   }
 
-  if (zodSchema instanceof ZodNumber) {
+  if (isZodType(zodSchema, 'ZodNumber')) {
     return createNumberSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodBoolean) {
+  if (isZodType(zodSchema, 'ZodBoolean')) {
     return createBooleanSchema(zodSchema);
   }
 
-  if (zodSchema instanceof ZodEnum) {
+  if (isZodType(zodSchema, 'ZodEnum')) {
     return createEnumSchema(zodSchema);
   }
 
-  if (zodSchema instanceof ZodLiteral) {
+  if (isZodType(zodSchema, 'ZodLiteral')) {
     return createLiteralSchema(zodSchema);
   }
 
-  if (zodSchema instanceof ZodNativeEnum) {
+  if (isZodType(zodSchema, 'ZodNativeEnum')) {
     return createNativeEnumSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodArray) {
+  if (isZodType(zodSchema, 'ZodArray')) {
     return createArraySchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodObject) {
+  if (isZodType(zodSchema, 'ZodObject')) {
     return createObjectSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodUnion) {
+  if (isZodType(zodSchema, 'ZodUnion')) {
     return createUnionSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodDiscriminatedUnion) {
+  if (isZodType(zodSchema, 'ZodDiscriminatedUnion')) {
     return createDiscriminatedUnionSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodNull) {
+  if (isZodType(zodSchema, 'ZodNull')) {
     return createNullSchema(zodSchema);
   }
 
-  if (zodSchema instanceof ZodNullable) {
+  if (isZodType(zodSchema, 'ZodNullable')) {
     return createNullableSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodOptional) {
+  if (isZodType(zodSchema, 'ZodOptional')) {
     return createOptionalSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodDefault) {
+  if (isZodType(zodSchema, 'ZodDefault')) {
     return createDefaultSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodRecord) {
+  if (isZodType(zodSchema, 'ZodRecord')) {
     return createRecordSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodTuple) {
+  if (isZodType(zodSchema, 'ZodTuple')) {
     return createTupleSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodDate) {
+  if (isZodType(zodSchema, 'ZodDate')) {
     return createDateSchema(zodSchema);
   }
 
-  if (zodSchema instanceof ZodPipeline) {
+  if (isZodType(zodSchema, 'ZodPipeline')) {
     return createPipelineSchema(zodSchema, state);
   }
 
   if (
-    zodSchema instanceof ZodEffects &&
+    isZodType(zodSchema, 'ZodEffects') &&
     zodSchema._def.effect.type === 'transform'
   ) {
     return createTransformSchema(zodSchema, state);
   }
 
   if (
-    zodSchema instanceof ZodEffects &&
+    isZodType(zodSchema, 'ZodEffects') &&
     zodSchema._def.effect.type === 'preprocess'
   ) {
     return createPreprocessSchema(zodSchema, state);
   }
 
   if (
-    zodSchema instanceof ZodEffects &&
+    isZodType(zodSchema, 'ZodEffects') &&
     zodSchema._def.effect.type === 'refinement'
   ) {
     return createRefineSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodNativeEnum) {
+  if (isZodType(zodSchema, 'ZodNativeEnum')) {
     return createNativeEnumSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodIntersection) {
+  if (isZodType(zodSchema, 'ZodIntersection')) {
     return createIntersectionSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodCatch) {
+  if (isZodType(zodSchema, 'ZodCatch')) {
     return createCatchSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodUnknown || zodSchema instanceof ZodAny) {
+  if (isZodType(zodSchema, 'ZodUnknown') || isZodType(zodSchema, 'ZodAny')) {
     return createUnknownSchema(zodSchema);
   }
 
-  if (zodSchema instanceof ZodLazy) {
+  if (isZodType(zodSchema, 'ZodLazy')) {
     return createLazySchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodBranded) {
+  if (isZodType(zodSchema, 'ZodBranded')) {
     return createBrandedSchema(zodSchema, state);
   }
 
-  if (zodSchema instanceof ZodSet) {
+  if (isZodType(zodSchema, 'ZodSet')) {
     return createSetSchema(zodSchema, state);
   }
 

--- a/src/create/schema/parsers/manual.ts
+++ b/src/create/schema/parsers/manual.ts
@@ -1,6 +1,7 @@
-import { ZodEffects, type ZodType, type ZodTypeDef } from 'zod';
+import type { ZodType, ZodTypeDef } from 'zod';
 
 import type { oas31 } from '../../../openapi3-ts/dist';
+import { isZodType } from '../../../zodType';
 import type { SchemaState } from '../../schema';
 
 export const createManualTypeSchema = <
@@ -13,7 +14,7 @@ export const createManualTypeSchema = <
 ): oas31.SchemaObject => {
   if (!zodSchema._def.openapi?.type) {
     const zodType = zodSchema.constructor.name;
-    if (zodSchema instanceof ZodEffects) {
+    if (isZodType(zodSchema, 'ZodEffects')) {
       const schemaName = `${zodType} - ${zodSchema._def.effect.type}`;
       throw new Error(
         `Unknown schema ${schemaName} at ${state.path.join(

--- a/src/create/schema/parsers/object.ts
+++ b/src/create/schema/parsers/object.ts
@@ -1,12 +1,7 @@
-import {
-  type UnknownKeysParam,
-  ZodNever,
-  type ZodObject,
-  type ZodRawShape,
-  type ZodType,
-} from 'zod';
+import type { UnknownKeysParam, ZodObject, ZodRawShape, ZodType } from 'zod';
 
 import type { oas31 } from '../../../openapi3-ts/dist';
+import { isZodType } from '../../../zodType';
 import { createComponentSchemaRef } from '../../components';
 import { type SchemaState, createSchemaObject } from '../../schema';
 
@@ -93,7 +88,7 @@ const createDiffOpts = (
 ): AdditionalPropertyOptions | undefined => {
   if (
     baseOpts.unknownKeys === 'strict' ||
-    !(baseOpts.catchAll instanceof ZodNever)
+    !isZodType(baseOpts.catchAll, 'ZodNever')
   ) {
     return undefined;
   }
@@ -144,7 +139,7 @@ export const createObjectSchemaFromShape = (
     ...(properties && { properties }),
     ...(required && { required }),
     ...(unknownKeys === 'strict' && { additionalProperties: false }),
-    ...(!(catchAll instanceof ZodNever) && {
+    ...(!isZodType(catchAll, 'ZodNever') && {
       additionalProperties: createSchemaObject(catchAll, state, [
         'additional properties',
       ]),

--- a/src/create/schema/parsers/optional.ts
+++ b/src/create/schema/parsers/optional.ts
@@ -1,19 +1,7 @@
-import {
-  ZodCatch,
-  ZodDefault,
-  ZodDiscriminatedUnion,
-  ZodEffects,
-  ZodIntersection,
-  ZodLazy,
-  ZodNullable,
-  ZodOptional,
-  ZodPipeline,
-  type ZodType,
-  type ZodTypeAny,
-  ZodUnion,
-} from 'zod';
+import type { ZodOptional, ZodType, ZodTypeAny } from 'zod';
 
 import type { oas31 } from '../../../openapi3-ts/dist';
+import { isZodType } from '../../../zodType';
 import { type SchemaState, createSchemaObject } from '../../schema';
 
 export const createOptionalSchema = (
@@ -26,34 +14,37 @@ export const isOptionalSchema = (
   zodSchema: ZodTypeAny,
   state: SchemaState,
 ): boolean => {
-  if (zodSchema instanceof ZodOptional || zodSchema instanceof ZodDefault) {
+  if (
+    isZodType(zodSchema, 'ZodOptional') ||
+    isZodType(zodSchema, 'ZodDefault')
+  ) {
     return true;
   }
 
-  if (zodSchema instanceof ZodNullable || zodSchema instanceof ZodCatch) {
+  if (isZodType(zodSchema, 'ZodNullable') || isZodType(zodSchema, 'ZodCatch')) {
     return isOptionalSchema(zodSchema._def.innerType as ZodTypeAny, state);
   }
 
-  if (zodSchema instanceof ZodEffects) {
+  if (isZodType(zodSchema, 'ZodEffects')) {
     return isOptionalSchema(zodSchema._def.schema as ZodTypeAny, state);
   }
 
   if (
-    zodSchema instanceof ZodUnion ||
-    zodSchema instanceof ZodDiscriminatedUnion
+    isZodType(zodSchema, 'ZodUnion') ||
+    isZodType(zodSchema, 'ZodDiscriminatedUnion')
   ) {
     return (zodSchema._def.options as ZodTypeAny[]).some((schema) =>
       isOptionalSchema(schema, state),
     );
   }
 
-  if (zodSchema instanceof ZodIntersection) {
+  if (isZodType(zodSchema, 'ZodIntersection')) {
     return [zodSchema._def.left, zodSchema._def.right].some((schema) =>
       isOptionalSchema(schema as ZodTypeAny, state),
     );
   }
 
-  if (zodSchema instanceof ZodPipeline) {
+  if (isZodType(zodSchema, 'ZodPipeline')) {
     if (
       state.effectType === 'input' ||
       (state.type === 'input' && state.effectType !== 'output')
@@ -69,7 +60,7 @@ export const isOptionalSchema = (
     }
   }
 
-  if (zodSchema instanceof ZodLazy) {
+  if (isZodType(zodSchema, 'ZodLazy')) {
     return isOptionalSchema(zodSchema._def.getter() as ZodType, state);
   }
 

--- a/src/zodType.ts
+++ b/src/zodType.ts
@@ -1,0 +1,97 @@
+// Inspired by https://github.com/asteasolutions/zod-to-openapi/blob/master/src/lib/zod-is-type.ts
+
+import type {
+  ZodAny,
+  ZodArray,
+  ZodBigInt,
+  ZodBoolean,
+  ZodBranded,
+  ZodCatch,
+  ZodDate,
+  ZodDefault,
+  ZodDiscriminatedUnion,
+  ZodEffects,
+  ZodEnum,
+  ZodFirstPartyTypeKind,
+  ZodFunction,
+  ZodIntersection,
+  ZodLazy,
+  ZodLiteral,
+  ZodMap,
+  ZodNaN,
+  ZodNativeEnum,
+  ZodNever,
+  ZodNull,
+  ZodNullable,
+  ZodNumber,
+  ZodObject,
+  ZodOptional,
+  ZodPipeline,
+  ZodPromise,
+  ZodRecord,
+  ZodSet,
+  ZodString,
+  ZodSymbol,
+  ZodTuple,
+  ZodType,
+  ZodTypeDef,
+  ZodUndefined,
+  ZodUnion,
+  ZodUnknown,
+  ZodVoid,
+} from 'zod';
+
+type ZodTypeMap = {
+  ZodAny: ZodAny;
+  ZodArray: ZodArray<any>;
+  ZodBigInt: ZodBigInt;
+  ZodBoolean: ZodBoolean;
+  ZodBranded: ZodBranded<any, any>;
+  ZodCatch: ZodCatch<any>;
+  ZodDate: ZodDate;
+  ZodDefault: ZodDefault<any>;
+  ZodDiscriminatedUnion: ZodDiscriminatedUnion<any, any>;
+  ZodEffects: ZodEffects<any>;
+  ZodEnum: ZodEnum<any>;
+  ZodFunction: ZodFunction<any, any>;
+  ZodIntersection: ZodIntersection<any, any>;
+  ZodLazy: ZodLazy<any>;
+  ZodLiteral: ZodLiteral<any>;
+  ZodMap: ZodMap;
+  ZodNaN: ZodNaN;
+  ZodNativeEnum: ZodNativeEnum<any>;
+  ZodNever: ZodNever;
+  ZodNull: ZodNull;
+  ZodNullable: ZodNullable<any>;
+  ZodNumber: ZodNumber;
+  ZodObject: ZodObject<any>;
+  ZodOptional: ZodOptional<any>;
+  ZodPipeline: ZodPipeline<any, any>;
+  ZodPromise: ZodPromise<any>;
+  ZodRecord: ZodRecord;
+  ZodSet: ZodSet;
+  ZodString: ZodString;
+  ZodSymbol: ZodSymbol;
+  ZodTuple: ZodTuple;
+  ZodUndefined: ZodUndefined;
+  ZodUnion: ZodUnion<any>;
+  ZodUnknown: ZodUnknown;
+  ZodVoid: ZodVoid;
+};
+
+export const isZodType = <U extends keyof ZodTypeMap>(
+  zodType: unknown,
+  typeName: U,
+): zodType is ZodTypeMap[U] =>
+  (
+    (zodType as ZodType)?._def as ZodTypeDef & {
+      typeName: ZodFirstPartyTypeKind; // FIXME: https://github.com/colinhacks/zod/pull/2459
+    }
+  ).typeName === typeName;
+
+export const isAnyZodType = (zodType: unknown): zodType is ZodType =>
+  Boolean(
+    (zodType as ZodType)?._def as ZodTypeDef & {
+      typeName: ZodFirstPartyTypeKind;
+    },
+  );


### PR DESCRIPTION
Had a consumer message me about issues. Turns out there is a variance in versions of Zod between the Zod version his library was using versus the Zod version the library was relying on. This meant that `instanceof` check was not working as intended. Instead, we will now rely on zodType._def.typeName. I am avoiding pulling in the enum to avoid version drift

https://github.com/colinhacks/zod/pull/2459 prevents us from having nice types