### PR TITLE
Allow parameter schemas to be ZodLazy, ZodPipeline, ZodBrand, or ZodEffects that output objects

### DIFF
--- a/src/create/document.ts
+++ b/src/create/document.ts
@@ -13,6 +13,7 @@ import type { oas30, oas31 } from '../openapi3-ts/dist';
 
 import { createComponents, getDefaultComponents } from './components';
 import { createPaths } from './paths';
+import { isZodType } from '../zodType';
 
 export interface ZodOpenApiMediaTypeObject
   extends Omit<oas31.MediaTypeObject & oas30.MediaTypeObject, 'schema'> {
@@ -55,26 +56,25 @@ export interface ZodOpenApiResponsesObject
 
 export type AnyObjectZodType = ZodType<object, any, any>;
 
-export const getZodObject = (schema: AnyObjectZodType): AnyZodObject => {
-  if (schema instanceof ZodObject) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return schema as any;
+export function getZodObject(schema: AnyObjectZodType): AnyZodObject {
+  if (isZodType(schema, 'ZodObject')) {
+    return schema;
   }
-  if (schema instanceof ZodLazy) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return getZodObject(schema.schema);
+  if (isZodType(schema, 'ZodLazy')) {
+    return getZodObject((schema as ZodLazy<AnyObjectZodType>).schema);
   }
-  if (schema instanceof ZodEffects) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return getZodObject(schema.innerType());
+  if (isZodType(schema, 'ZodEffects')) {
+    return getZodObject(
+      (schema as ZodEffects<AnyObjectZodType, object, any>).innerType(),
+    );
   }
-  if (schema instanceof ZodBranded) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return getZodObject(schema.unwrap());
+  if (isZodType(schema, 'ZodBranded')) {
+    return getZodObject((schema as ZodBranded<AnyObjectZodType, any>).unwrap());
   }
-  if (schema instanceof ZodPipeline) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return getZodObject(schema._def.out);
+  if (isZodType(schema, 'ZodPipeline')) {
+    return getZodObject(
+      (schema as ZodPipeline<any, AnyObjectZodType>)._def.out,
+    );
   }
   throw new Error('failed to find ZodObject in schema');
 }

--- a/src/create/document.ts
+++ b/src/create/document.ts
@@ -55,7 +55,7 @@ export interface ZodOpenApiResponsesObject
 
 export type AnyObjectZodType = ZodType<object, any, any>;
 
-export function getZodObject(schema: AnyObjectZodType): AnyZodObject {
+export const getZodObject = (schema: AnyObjectZodType): AnyZodObject => {
   if (schema instanceof ZodObject) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return schema as any;

--- a/src/create/parameters.test.ts
+++ b/src/create/parameters.test.ts
@@ -111,6 +111,76 @@ describe('createParametersObject', () => {
     expect(result).toStrictEqual(expectedResult);
   });
 
+  it('should support wrapped ZodObject schema', () => {
+    const expectedResult: oas31.OperationObject['parameters'] = [
+      {
+        in: 'path',
+        name: 'b',
+        schema: {
+          type: 'string',
+        },
+        required: true,
+      },
+      {
+        in: 'query',
+        name: 'a',
+        schema: {
+          type: 'string',
+        },
+        required: true,
+      },
+      {
+        in: 'cookie',
+        name: 'c',
+        schema: {
+          type: 'string',
+        },
+        required: true,
+      },
+      {
+        in: 'header',
+        name: 'd',
+        schema: {
+          type: 'string',
+        },
+        required: true,
+      },
+    ];
+    const result = createParametersObject(
+      [],
+      {
+        path: z
+          .lazy(() =>
+            z.object({ b: z.string() }).pipe(z.object({ b: z.string() })),
+          )
+          .brand('test')
+          .transform((x) => x),
+        query: z
+          .lazy(() =>
+            z.object({ a: z.string() }).pipe(z.object({ a: z.string() })),
+          )
+          .brand('test')
+          .transform((x) => x),
+        cookie: z
+          .lazy(() =>
+            z.object({ c: z.string() }).pipe(z.object({ c: z.string() })),
+          )
+          .brand('test')
+          .transform((x) => x),
+        header: z
+          .lazy(() =>
+            z.object({ d: z.string() }).pipe(z.object({ d: z.string() })),
+          )
+          .brand('test')
+          .transform((x) => x),
+      },
+      getDefaultComponents(),
+      ['parameters'],
+    );
+
+    expect(result).toStrictEqual(expectedResult);
+  });
+
   it('should combine parameters with requestParams', () => {
     const expectedResult: oas31.OperationObject['parameters'] = [
       {

--- a/src/create/parameters.ts
+++ b/src/create/parameters.ts
@@ -1,10 +1,14 @@
-import type { AnyZodObject, ZodRawShape, ZodType } from 'zod';
+import type { ZodRawShape, ZodType } from 'zod';
 
 import type { oas30, oas31 } from '../openapi3-ts/dist';
 import { isAnyZodType } from '../zodType';
 
 import type { ComponentsObject } from './components';
-import type { ZodOpenApiParameters } from './document';
+import {
+  type AnyObjectZodType,
+  type ZodOpenApiParameters,
+  getZodObject,
+} from './document';
 import { type SchemaState, createSchemaObject, newSchemaState } from './schema';
 import { isOptionalSchema } from './schema/parsers/optional';
 
@@ -100,13 +104,14 @@ export const createParamOrRef = (
 
 const createParameters = (
   type: keyof ZodOpenApiParameters,
-  zodObject: AnyZodObject | undefined,
+  schema: AnyObjectZodType | undefined,
   components: ComponentsObject,
   subpath: string[],
 ): (oas31.ParameterObject | oas31.ReferenceObject)[] => {
-  if (!zodObject) {
+  if (!schema) {
     return [];
   }
+  const zodObject = getZodObject(schema);
 
   return Object.entries(zodObject.shape as ZodRawShape).map(
     ([key, zodSchema]: [string, ZodType]) =>


### PR DESCRIPTION
I started needing to use ZodLazy in parameters to deal with import order issues, so the fact that parameters currently have to be an instance of ZodObject is feeling overly restrictive