### PR TITLE
Add `type: object` to discriminated union schema

### DIFF
--- a/src/create/document.test.ts
+++ b/src/create/document.test.ts
@@ -341,302 +341,304 @@ describe('createDocument', () => {
     const document = createDocument(complexZodOpenApiObject);
 
     expect(document).toMatchInlineSnapshot(`
-      {
-        "components": {
-          "headers": {
-            "my-header": {
-              "required": true,
-              "schema": {
-                "type": "string",
-              },
-            },
+{
+  "components": {
+    "headers": {
+      "my-header": {
+        "required": true,
+        "schema": {
+          "type": "string",
+        },
+      },
+    },
+    "parameters": {
+      "b": {
+        "in": "path",
+        "name": "b",
+        "required": true,
+        "schema": {
+          "type": "string",
+        },
+      },
+    },
+    "schemas": {
+      "a": {
+        "type": "string",
+      },
+      "b": {
+        "properties": {
+          "a": {
+            "type": "string",
           },
-          "parameters": {
-            "b": {
-              "in": "path",
-              "name": "b",
-              "required": true,
-              "schema": {
-                "type": "string",
-              },
-            },
+        },
+        "required": [
+          "a",
+        ],
+        "type": "object",
+      },
+      "c": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/b",
           },
-          "schemas": {
-            "a": {
-              "type": "string",
+        ],
+        "properties": {
+          "d": {
+            "type": [
+              "string",
+              "null",
+            ],
+          },
+        },
+        "required": [
+          "d",
+        ],
+        "type": "object",
+      },
+      "lazy": {
+        "items": {
+          "$ref": "#/components/schemas/lazy",
+        },
+        "type": "array",
+      },
+      "manual": {
+        "type": "boolean",
+      },
+      "post": {
+        "properties": {
+          "id": {
+            "type": "string",
+          },
+          "user": {
+            "$ref": "#/components/schemas/user",
+          },
+          "userId": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "userId",
+        ],
+        "type": "object",
+      },
+      "union-a": {
+        "properties": {
+          "type": {
+            "enum": [
+              "a",
+            ],
+            "type": "string",
+          },
+        },
+        "required": [
+          "type",
+        ],
+        "type": "object",
+      },
+      "union-b": {
+        "properties": {
+          "type": {
+            "enum": [
+              "b",
+            ],
+            "type": "string",
+          },
+        },
+        "required": [
+          "type",
+        ],
+        "type": "object",
+      },
+      "user": {
+        "properties": {
+          "id": {
+            "type": "string",
+          },
+          "posts": {
+            "items": {
+              "$ref": "#/components/schemas/post",
             },
-            "b": {
-              "properties": {
-                "a": {
-                  "type": "string",
-                },
-              },
-              "required": [
-                "a",
-              ],
-              "type": "object",
-            },
-            "c": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/b",
-                },
-              ],
-              "properties": {
-                "d": {
-                  "type": [
-                    "string",
-                    "null",
-                  ],
-                },
-              },
-              "required": [
-                "d",
-              ],
-              "type": "object",
-            },
-            "lazy": {
-              "items": {
-                "$ref": "#/components/schemas/lazy",
-              },
-              "type": "array",
-            },
-            "manual": {
-              "type": "boolean",
-            },
-            "post": {
-              "properties": {
-                "id": {
-                  "type": "string",
-                },
-                "user": {
-                  "$ref": "#/components/schemas/user",
-                },
-                "userId": {
-                  "type": "string",
-                },
-              },
-              "required": [
-                "id",
-                "userId",
-              ],
-              "type": "object",
-            },
-            "union-a": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "a",
-                  ],
-                  "type": "string",
-                },
-              },
-              "required": [
-                "type",
-              ],
-              "type": "object",
-            },
-            "union-b": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "b",
-                  ],
-                  "type": "string",
-                },
-              },
-              "required": [
-                "type",
-              ],
-              "type": "object",
-            },
-            "user": {
-              "properties": {
-                "id": {
-                  "type": "string",
-                },
-                "posts": {
-                  "items": {
-                    "$ref": "#/components/schemas/post",
+            "type": "array",
+          },
+        },
+        "required": [
+          "id",
+        ],
+        "type": "object",
+      },
+    },
+  },
+  "info": {
+    "title": "My API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/jobs": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/b",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "a": {
+                    "$ref": "#/components/schemas/a",
                   },
-                  "type": "array",
+                  "b": {
+                    "$ref": "#/components/schemas/b",
+                  },
+                  "c": {
+                    "$ref": "#/components/schemas/b",
+                  },
+                  "d": {
+                    "$ref": "#/components/schemas/c",
+                  },
+                  "e": {
+                    "discriminator": {
+                      "mapping": {
+                        "a": "#/components/schemas/union-a",
+                        "b": "#/components/schemas/union-b",
+                      },
+                      "propertyName": "type",
+                    },
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/union-a",
+                      },
+                      {
+                        "$ref": "#/components/schemas/union-b",
+                      },
+                    ],
+                    "type": "object",
+                  },
+                  "f": {
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "prefixItems": [
+                      {
+                        "type": "string",
+                      },
+                      {
+                        "type": "number",
+                      },
+                      {
+                        "$ref": "#/components/schemas/manual",
+                      },
+                    ],
+                    "type": "array",
+                  },
+                  "g": {
+                    "$ref": "#/components/schemas/lazy",
+                  },
+                  "h": {
+                    "$ref": "#/components/schemas/user",
+                  },
                 },
+                "required": [
+                  "a",
+                  "b",
+                  "d",
+                  "e",
+                  "f",
+                  "g",
+                  "h",
+                ],
+                "type": "object",
               },
-              "required": [
-                "id",
-              ],
-              "type": "object",
             },
           },
         },
-        "info": {
-          "title": "My API",
-          "version": "1.0.0",
-        },
-        "openapi": "3.1.0",
-        "paths": {
-          "/jobs": {
-            "get": {
-              "parameters": [
-                {
-                  "$ref": "#/components/parameters/b",
-                },
-              ],
-              "requestBody": {
-                "content": {
-                  "application/json": {
-                    "schema": {
-                      "properties": {
-                        "a": {
-                          "$ref": "#/components/schemas/a",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "a": {
+                      "$ref": "#/components/schemas/a",
+                    },
+                    "b": {
+                      "$ref": "#/components/schemas/b",
+                    },
+                    "c": {
+                      "$ref": "#/components/schemas/b",
+                    },
+                    "d": {
+                      "$ref": "#/components/schemas/c",
+                    },
+                    "e": {
+                      "discriminator": {
+                        "mapping": {
+                          "a": "#/components/schemas/union-a",
+                          "b": "#/components/schemas/union-b",
                         },
-                        "b": {
-                          "$ref": "#/components/schemas/b",
-                        },
-                        "c": {
-                          "$ref": "#/components/schemas/b",
-                        },
-                        "d": {
-                          "$ref": "#/components/schemas/c",
-                        },
-                        "e": {
-                          "discriminator": {
-                            "mapping": {
-                              "a": "#/components/schemas/union-a",
-                              "b": "#/components/schemas/union-b",
-                            },
-                            "propertyName": "type",
-                          },
-                          "oneOf": [
-                            {
-                              "$ref": "#/components/schemas/union-a",
-                            },
-                            {
-                              "$ref": "#/components/schemas/union-b",
-                            },
-                          ],
-                        },
-                        "f": {
-                          "maxItems": 3,
-                          "minItems": 3,
-                          "prefixItems": [
-                            {
-                              "type": "string",
-                            },
-                            {
-                              "type": "number",
-                            },
-                            {
-                              "$ref": "#/components/schemas/manual",
-                            },
-                          ],
-                          "type": "array",
-                        },
-                        "g": {
-                          "$ref": "#/components/schemas/lazy",
-                        },
-                        "h": {
-                          "$ref": "#/components/schemas/user",
-                        },
+                        "propertyName": "type",
                       },
-                      "required": [
-                        "a",
-                        "b",
-                        "d",
-                        "e",
-                        "f",
-                        "g",
-                        "h",
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/union-a",
+                        },
+                        {
+                          "$ref": "#/components/schemas/union-b",
+                        },
                       ],
                       "type": "object",
                     },
+                    "f": {
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "prefixItems": [
+                        {
+                          "type": "string",
+                        },
+                        {
+                          "type": "number",
+                        },
+                        {
+                          "$ref": "#/components/schemas/manual",
+                        },
+                      ],
+                      "type": "array",
+                    },
+                    "g": {
+                      "$ref": "#/components/schemas/lazy",
+                    },
+                    "h": {
+                      "$ref": "#/components/schemas/user",
+                    },
                   },
+                  "required": [
+                    "a",
+                    "b",
+                    "d",
+                    "e",
+                    "f",
+                    "g",
+                    "h",
+                  ],
+                  "type": "object",
                 },
               },
-              "responses": {
-                "200": {
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "properties": {
-                          "a": {
-                            "$ref": "#/components/schemas/a",
-                          },
-                          "b": {
-                            "$ref": "#/components/schemas/b",
-                          },
-                          "c": {
-                            "$ref": "#/components/schemas/b",
-                          },
-                          "d": {
-                            "$ref": "#/components/schemas/c",
-                          },
-                          "e": {
-                            "discriminator": {
-                              "mapping": {
-                                "a": "#/components/schemas/union-a",
-                                "b": "#/components/schemas/union-b",
-                              },
-                              "propertyName": "type",
-                            },
-                            "oneOf": [
-                              {
-                                "$ref": "#/components/schemas/union-a",
-                              },
-                              {
-                                "$ref": "#/components/schemas/union-b",
-                              },
-                            ],
-                          },
-                          "f": {
-                            "maxItems": 3,
-                            "minItems": 3,
-                            "prefixItems": [
-                              {
-                                "type": "string",
-                              },
-                              {
-                                "type": "number",
-                              },
-                              {
-                                "$ref": "#/components/schemas/manual",
-                              },
-                            ],
-                            "type": "array",
-                          },
-                          "g": {
-                            "$ref": "#/components/schemas/lazy",
-                          },
-                          "h": {
-                            "$ref": "#/components/schemas/user",
-                          },
-                        },
-                        "required": [
-                          "a",
-                          "b",
-                          "d",
-                          "e",
-                          "f",
-                          "g",
-                          "h",
-                        ],
-                        "type": "object",
-                      },
-                    },
-                  },
-                  "description": "200 OK",
-                  "headers": {
-                    "my-header": {
-                      "$ref": "#/components/headers/my-header",
-                    },
-                  },
-                },
+            },
+            "description": "200 OK",
+            "headers": {
+              "my-header": {
+                "$ref": "#/components/headers/my-header",
               },
             },
           },
         },
-      }
-    `);
+      },
+    },
+  },
+}
+`);
   });
 
   it('should generate a complex JSON document string with components in 3.0.0', () => {
@@ -646,304 +648,306 @@ describe('createDocument', () => {
     });
 
     expect(document).toMatchInlineSnapshot(`
-      {
-        "components": {
-          "headers": {
-            "my-header": {
-              "required": true,
-              "schema": {
-                "type": "string",
-              },
-            },
+{
+  "components": {
+    "headers": {
+      "my-header": {
+        "required": true,
+        "schema": {
+          "type": "string",
+        },
+      },
+    },
+    "parameters": {
+      "b": {
+        "in": "path",
+        "name": "b",
+        "required": true,
+        "schema": {
+          "type": "string",
+        },
+      },
+    },
+    "schemas": {
+      "a": {
+        "type": "string",
+      },
+      "b": {
+        "properties": {
+          "a": {
+            "type": "string",
           },
-          "parameters": {
-            "b": {
-              "in": "path",
-              "name": "b",
-              "required": true,
-              "schema": {
-                "type": "string",
-              },
-            },
+        },
+        "required": [
+          "a",
+        ],
+        "type": "object",
+      },
+      "c": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/b",
           },
-          "schemas": {
-            "a": {
-              "type": "string",
+        ],
+        "properties": {
+          "d": {
+            "nullable": true,
+            "type": "string",
+          },
+        },
+        "required": [
+          "d",
+        ],
+        "type": "object",
+      },
+      "lazy": {
+        "items": {
+          "$ref": "#/components/schemas/lazy",
+        },
+        "type": "array",
+      },
+      "manual": {
+        "type": "boolean",
+      },
+      "post": {
+        "properties": {
+          "id": {
+            "type": "string",
+          },
+          "user": {
+            "$ref": "#/components/schemas/user",
+          },
+          "userId": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "userId",
+        ],
+        "type": "object",
+      },
+      "union-a": {
+        "properties": {
+          "type": {
+            "enum": [
+              "a",
+            ],
+            "type": "string",
+          },
+        },
+        "required": [
+          "type",
+        ],
+        "type": "object",
+      },
+      "union-b": {
+        "properties": {
+          "type": {
+            "enum": [
+              "b",
+            ],
+            "type": "string",
+          },
+        },
+        "required": [
+          "type",
+        ],
+        "type": "object",
+      },
+      "user": {
+        "properties": {
+          "id": {
+            "type": "string",
+          },
+          "posts": {
+            "items": {
+              "$ref": "#/components/schemas/post",
             },
-            "b": {
-              "properties": {
-                "a": {
-                  "type": "string",
-                },
-              },
-              "required": [
-                "a",
-              ],
-              "type": "object",
-            },
-            "c": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/b",
-                },
-              ],
-              "properties": {
-                "d": {
-                  "nullable": true,
-                  "type": "string",
-                },
-              },
-              "required": [
-                "d",
-              ],
-              "type": "object",
-            },
-            "lazy": {
-              "items": {
-                "$ref": "#/components/schemas/lazy",
-              },
-              "type": "array",
-            },
-            "manual": {
-              "type": "boolean",
-            },
-            "post": {
-              "properties": {
-                "id": {
-                  "type": "string",
-                },
-                "user": {
-                  "$ref": "#/components/schemas/user",
-                },
-                "userId": {
-                  "type": "string",
-                },
-              },
-              "required": [
-                "id",
-                "userId",
-              ],
-              "type": "object",
-            },
-            "union-a": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "a",
-                  ],
-                  "type": "string",
-                },
-              },
-              "required": [
-                "type",
-              ],
-              "type": "object",
-            },
-            "union-b": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "b",
-                  ],
-                  "type": "string",
-                },
-              },
-              "required": [
-                "type",
-              ],
-              "type": "object",
-            },
-            "user": {
-              "properties": {
-                "id": {
-                  "type": "string",
-                },
-                "posts": {
-                  "items": {
-                    "$ref": "#/components/schemas/post",
+            "type": "array",
+          },
+        },
+        "required": [
+          "id",
+        ],
+        "type": "object",
+      },
+    },
+  },
+  "info": {
+    "title": "My API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/jobs": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/b",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "a": {
+                    "$ref": "#/components/schemas/a",
                   },
-                  "type": "array",
+                  "b": {
+                    "$ref": "#/components/schemas/b",
+                  },
+                  "c": {
+                    "$ref": "#/components/schemas/b",
+                  },
+                  "d": {
+                    "$ref": "#/components/schemas/c",
+                  },
+                  "e": {
+                    "discriminator": {
+                      "mapping": {
+                        "a": "#/components/schemas/union-a",
+                        "b": "#/components/schemas/union-b",
+                      },
+                      "propertyName": "type",
+                    },
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/union-a",
+                      },
+                      {
+                        "$ref": "#/components/schemas/union-b",
+                      },
+                    ],
+                    "type": "object",
+                  },
+                  "f": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "string",
+                        },
+                        {
+                          "type": "number",
+                        },
+                        {
+                          "$ref": "#/components/schemas/manual",
+                        },
+                      ],
+                    },
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "type": "array",
+                  },
+                  "g": {
+                    "$ref": "#/components/schemas/lazy",
+                  },
+                  "h": {
+                    "$ref": "#/components/schemas/user",
+                  },
                 },
+                "required": [
+                  "a",
+                  "b",
+                  "d",
+                  "e",
+                  "f",
+                  "g",
+                  "h",
+                ],
+                "type": "object",
               },
-              "required": [
-                "id",
-              ],
-              "type": "object",
             },
           },
         },
-        "info": {
-          "title": "My API",
-          "version": "1.0.0",
-        },
-        "openapi": "3.0.0",
-        "paths": {
-          "/jobs": {
-            "get": {
-              "parameters": [
-                {
-                  "$ref": "#/components/parameters/b",
-                },
-              ],
-              "requestBody": {
-                "content": {
-                  "application/json": {
-                    "schema": {
-                      "properties": {
-                        "a": {
-                          "$ref": "#/components/schemas/a",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "a": {
+                      "$ref": "#/components/schemas/a",
+                    },
+                    "b": {
+                      "$ref": "#/components/schemas/b",
+                    },
+                    "c": {
+                      "$ref": "#/components/schemas/b",
+                    },
+                    "d": {
+                      "$ref": "#/components/schemas/c",
+                    },
+                    "e": {
+                      "discriminator": {
+                        "mapping": {
+                          "a": "#/components/schemas/union-a",
+                          "b": "#/components/schemas/union-b",
                         },
-                        "b": {
-                          "$ref": "#/components/schemas/b",
-                        },
-                        "c": {
-                          "$ref": "#/components/schemas/b",
-                        },
-                        "d": {
-                          "$ref": "#/components/schemas/c",
-                        },
-                        "e": {
-                          "discriminator": {
-                            "mapping": {
-                              "a": "#/components/schemas/union-a",
-                              "b": "#/components/schemas/union-b",
-                            },
-                            "propertyName": "type",
-                          },
-                          "oneOf": [
-                            {
-                              "$ref": "#/components/schemas/union-a",
-                            },
-                            {
-                              "$ref": "#/components/schemas/union-b",
-                            },
-                          ],
-                        },
-                        "f": {
-                          "items": {
-                            "oneOf": [
-                              {
-                                "type": "string",
-                              },
-                              {
-                                "type": "number",
-                              },
-                              {
-                                "$ref": "#/components/schemas/manual",
-                              },
-                            ],
-                          },
-                          "maxItems": 3,
-                          "minItems": 3,
-                          "type": "array",
-                        },
-                        "g": {
-                          "$ref": "#/components/schemas/lazy",
-                        },
-                        "h": {
-                          "$ref": "#/components/schemas/user",
-                        },
+                        "propertyName": "type",
                       },
-                      "required": [
-                        "a",
-                        "b",
-                        "d",
-                        "e",
-                        "f",
-                        "g",
-                        "h",
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/union-a",
+                        },
+                        {
+                          "$ref": "#/components/schemas/union-b",
+                        },
                       ],
                       "type": "object",
                     },
+                    "f": {
+                      "items": {
+                        "oneOf": [
+                          {
+                            "type": "string",
+                          },
+                          {
+                            "type": "number",
+                          },
+                          {
+                            "$ref": "#/components/schemas/manual",
+                          },
+                        ],
+                      },
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "type": "array",
+                    },
+                    "g": {
+                      "$ref": "#/components/schemas/lazy",
+                    },
+                    "h": {
+                      "$ref": "#/components/schemas/user",
+                    },
                   },
+                  "required": [
+                    "a",
+                    "b",
+                    "d",
+                    "e",
+                    "f",
+                    "g",
+                    "h",
+                  ],
+                  "type": "object",
                 },
               },
-              "responses": {
-                "200": {
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "properties": {
-                          "a": {
-                            "$ref": "#/components/schemas/a",
-                          },
-                          "b": {
-                            "$ref": "#/components/schemas/b",
-                          },
-                          "c": {
-                            "$ref": "#/components/schemas/b",
-                          },
-                          "d": {
-                            "$ref": "#/components/schemas/c",
-                          },
-                          "e": {
-                            "discriminator": {
-                              "mapping": {
-                                "a": "#/components/schemas/union-a",
-                                "b": "#/components/schemas/union-b",
-                              },
-                              "propertyName": "type",
-                            },
-                            "oneOf": [
-                              {
-                                "$ref": "#/components/schemas/union-a",
-                              },
-                              {
-                                "$ref": "#/components/schemas/union-b",
-                              },
-                            ],
-                          },
-                          "f": {
-                            "items": {
-                              "oneOf": [
-                                {
-                                  "type": "string",
-                                },
-                                {
-                                  "type": "number",
-                                },
-                                {
-                                  "$ref": "#/components/schemas/manual",
-                                },
-                              ],
-                            },
-                            "maxItems": 3,
-                            "minItems": 3,
-                            "type": "array",
-                          },
-                          "g": {
-                            "$ref": "#/components/schemas/lazy",
-                          },
-                          "h": {
-                            "$ref": "#/components/schemas/user",
-                          },
-                        },
-                        "required": [
-                          "a",
-                          "b",
-                          "d",
-                          "e",
-                          "f",
-                          "g",
-                          "h",
-                        ],
-                        "type": "object",
-                      },
-                    },
-                  },
-                  "description": "200 OK",
-                  "headers": {
-                    "my-header": {
-                      "$ref": "#/components/headers/my-header",
-                    },
-                  },
-                },
+            },
+            "description": "200 OK",
+            "headers": {
+              "my-header": {
+                "$ref": "#/components/headers/my-header",
               },
             },
           },
         },
-      }
-    `);
+      },
+    },
+  },
+}
+`);
   });
 
   it('Supports circular schemas declared in components.schemas', () => {

--- a/src/create/schema/index.test.ts
+++ b/src/create/schema/index.test.ts
@@ -42,6 +42,7 @@ const zodDiscriminatedUnion = z.discriminatedUnion('type', [
   }),
 ]);
 const expectedZodDiscriminatedUnion: oas31.SchemaObject = {
+  type: 'object',
   oneOf: [
     {
       type: 'object',

--- a/src/create/schema/parsers/discriminatedUnion.test.ts
+++ b/src/create/schema/parsers/discriminatedUnion.test.ts
@@ -12,6 +12,7 @@ extendZodWithOpenApi(z);
 describe('createDiscriminatedUnionSchema', () => {
   it('creates a oneOf schema', () => {
     const expected: oas31.SchemaObject = {
+      type: 'object',
       oneOf: [
         {
           type: 'object',
@@ -51,6 +52,7 @@ describe('createDiscriminatedUnionSchema', () => {
 
   it('creates a oneOf schema with discriminator mapping when schemas are registered', () => {
     const expected: oas31.SchemaObject = {
+      type: 'object',
       oneOf: [
         { $ref: '#/components/schemas/a' },
         { $ref: '#/components/schemas/b' },
@@ -83,6 +85,7 @@ describe('createDiscriminatedUnionSchema', () => {
 
   it('creates a oneOf schema with discriminator mapping when schemas with enums are registered', () => {
     const expected: oas31.SchemaObject = {
+      type: 'object',
       oneOf: [
         { $ref: '#/components/schemas/c' },
         { $ref: '#/components/schemas/d' },
@@ -130,6 +133,7 @@ describe('createDiscriminatedUnionSchema', () => {
       },
     };
     const expected: oas31.SchemaObject = {
+      type: 'object',
       oneOf: [
         { $ref: '#/components/schemas/c' },
         { $ref: '#/components/schemas/d' },

--- a/src/create/schema/parsers/discriminatedUnion.ts
+++ b/src/create/schema/parsers/discriminatedUnion.ts
@@ -24,6 +24,7 @@ export const createDiscriminatedUnionSchema = (
     state,
   );
   return {
+    type: 'object',
     oneOf: schemas,
     ...(discriminator && { discriminator }),
   };


### PR DESCRIPTION
Discriminated Unions in Zod are always objects, so we can be a little more strict with the generated typing.