### PR TITLE
fix: default should be nonoptional in output state

### DIFF
--- a/src/create/schema/index.test.ts
+++ b/src/create/schema/index.test.ts
@@ -125,7 +125,7 @@ const expectedZodNumber: oas31.SchemaObject = {
 const zodObject = z.object({
   a: z.string(),
   b: z.string().optional(),
-  c: z.string().default('test-default')
+  c: z.string().default('test-default'),
 });
 const expectedZodObjectInput: oas31.SchemaObject = {
   type: 'object',

--- a/src/create/schema/index.test.ts
+++ b/src/create/schema/index.test.ts
@@ -125,14 +125,25 @@ const expectedZodNumber: oas31.SchemaObject = {
 const zodObject = z.object({
   a: z.string(),
   b: z.string().optional(),
+  c: z.string().default('test-default')
 });
-const expectedZodObject: oas31.SchemaObject = {
+const expectedZodObjectInput: oas31.SchemaObject = {
   type: 'object',
   properties: {
     a: { type: 'string' },
     b: { type: 'string' },
+    c: { type: 'string', default: 'test-default' },
   },
   required: ['a'],
+};
+const expectedZodObjectOutput: oas31.SchemaObject = {
+  type: 'object',
+  properties: {
+    a: { type: 'string' },
+    b: { type: 'string' },
+    c: { type: 'string', default: 'test-default' },
+  },
+  required: ['a', 'c'],
 };
 
 const zodOptional = z.string().optional();
@@ -300,7 +311,7 @@ describe('createSchemaObject', () => {
     ${'ZodNull'}                 | ${zodNull}               | ${expectedZodNull}
     ${'ZodNullable'}             | ${zodNullable}           | ${expectedZodNullable}
     ${'ZodNumber'}               | ${zodNumber}             | ${expectedZodNumber}
-    ${'ZodObject'}               | ${zodObject}             | ${expectedZodObject}
+    ${'ZodObject'}               | ${zodObject}             | ${expectedZodObjectOutput}
     ${'ZodOptional'}             | ${zodOptional}           | ${expectedZodOptional}
     ${'ZodRecord'}               | ${zodRecord}             | ${expectedZodRecord}
     ${'ZodString'}               | ${zodString}             | ${expectedZodString}
@@ -338,7 +349,7 @@ describe('createSchemaObject', () => {
     ${'ZodNull'}                 | ${zodNull}               | ${expectedZodNull}
     ${'ZodNullable'}             | ${zodNullable}           | ${expectedZodNullable}
     ${'ZodNumber'}               | ${zodNumber}             | ${expectedZodNumber}
-    ${'ZodObject'}               | ${zodObject}             | ${expectedZodObject}
+    ${'ZodObject'}               | ${zodObject}             | ${expectedZodObjectInput}
     ${'ZodOptional'}             | ${zodOptional}           | ${expectedZodOptional}
     ${'ZodRecord'}               | ${zodRecord}             | ${expectedZodRecord}
     ${'ZodString'}               | ${zodString}             | ${expectedZodString}

--- a/src/create/schema/parsers/optional.ts
+++ b/src/create/schema/parsers/optional.ts
@@ -14,11 +14,12 @@ export const isOptionalSchema = (
   zodSchema: ZodTypeAny,
   state: SchemaState,
 ): boolean => {
-  if (
-    isZodType(zodSchema, 'ZodOptional') ||
-    isZodType(zodSchema, 'ZodDefault')
-  ) {
+  if (isZodType(zodSchema, 'ZodOptional')) {
     return true;
+  }
+
+  if (isZodType(zodSchema, 'ZodDefault')) {
+    return state.type === 'input'
   }
 
   if (isZodType(zodSchema, 'ZodNullable') || isZodType(zodSchema, 'ZodCatch')) {

--- a/src/create/schema/parsers/optional.ts
+++ b/src/create/schema/parsers/optional.ts
@@ -19,7 +19,7 @@ export const isOptionalSchema = (
   }
 
   if (isZodType(zodSchema, 'ZodDefault')) {
-    return state.type === 'input'
+    return state.type === 'input';
   }
 
   if (isZodType(zodSchema, 'ZodNullable') || isZodType(zodSchema, 'ZodCatch')) {


### PR DESCRIPTION
## Purpose

`ZodDefault` should be considered optional only in `input` states

## Context

Encountered this bug in my project

```js
responses: {
    200: {
      description: "The Job that was created",
      content: {
        "application/json": {
          schema: z.object({
            data: JobSchema,
          }),
        },
      },
    },
}

// ...

const JobSchema = z.object({
  jobId: z.string().default(() => uuid()),
  userId: z.string(),
  schedule: z.string(),
  enabled: z.boolean(),
  endpoint: EndpointSchema,
});
```

Resulting in OpenAPI spec that didn't list `jobId` as required:

```
"schema": {
  "type": "object",
  "properties": {
    "data": {
      "type": "object",
      "properties": {
        "jobId": {
          "type": "string",
          "default": "97e6c4a9-f00c-427f-b1fa-87f115621ba8"
        },
      // ....
      },
      "required": ["userId", "schedule", "enabled", "endpoint"]
    }
  },
  "required": ["data"]
}
```