### PR TITLE
README: Fix path parameters extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Query, Path, Header & Cookie parameters can be created using the `requestParams`
 ```typescript
 createDocument({
   paths: {
-    '/jobs/:a': {
+    '/jobs/{a}': {
       put: {
         requestParams: {
           path: z.object({ a: z.string() }),
@@ -201,7 +201,7 @@ If you would like to declare parameters in a more traditional way you may also d
 ```ts
 createDocument({
   paths: {
-    '/jobs/:a': {
+    '/jobs/{a}': {
       put: {
         parameters: [
           z.string().openapi({


### PR DESCRIPTION
I'm unsure where does the `:param` syntax comes from since I couldn't find it in the OpenAPI 3.x spec.
Some OpenAPI generators (like Orval) fail to extract the path parameters if they are not written in the form of `{param}`.