### PR TITLE
Fix duplicate parameter component check

### DIFF
--- a/src/create/parameters.ts
+++ b/src/create/parameters.ts
@@ -62,7 +62,7 @@ export const createParamOrRef = (
   if (component && component.type === 'complete') {
     if (
       !('$ref' in component.paramObject) &&
-      (component.in !== type || component.name !== name)
+      (component.in !== paramType || component.name !== paramName)
     ) {
       throw new Error(`parameterRef "${component.ref}" is already registered`);
     }


### PR DESCRIPTION
This did not seem to work if the the same parameter component ref was being used in multiple path's `params: [paramRef]` arrays. I believe this is because `type` variable (passed as a parameter) was `undefined` in that case (being called from `createManualParameters`, it would instead come from `zodSchema._def.openapi.type`).

Being `undefined`, the `if` check would always fail if such a parameter already existed (even if it was identical).

This fixes it - it always compares with the value the parameter object would potentially be created with later on, ie. `paramType` and `paramName`.

_Observation:_
`const paramType = zodSchema._def?.openapi?.param?.in ?? component?.in ?? type` prefers the component's type instead of the passed `type` parameter.

Even in case the `type` mismatches (eg. passing an existing `type: path` ref as `requestParams: { query: { someParam: pathParamRef } }`, currently, I think, it would silently succeed.
