### PR TITLE
Fix ESM importing on Node.js

### DIFF
--- a/esbuild.esm.mjs
+++ b/esbuild.esm.mjs
@@ -7,4 +7,5 @@ await build({
   format: 'esm',
   target: ['es2022'],
   outdir: './lib-esm',
+  outExtension: { '.js': '.mjs' },
 });

--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
   },
   "license": "MIT",
   "sideEffects": false,
-  "main": "./lib-commonjs/index.js",
-  "module": "./lib-esm/index.mjs",
-  "types": "./lib-types/index.d.ts",
   "exports": {
     ".": {
       "import": "./lib-esm/index.mjs",
@@ -31,6 +28,9 @@
       "types": "./lib-types/index.d.ts"
     }
   },
+  "main": "./lib-commonjs/index.js",
+  "module": "./lib-esm/index.mjs",
+  "types": "./lib-types/index.d.ts",
   "files": [
     "lib*/**/*.d.ts",
     "lib*/**/*.{js,mjs}{,.map}",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,18 @@
   "license": "MIT",
   "sideEffects": false,
   "main": "./lib-commonjs/index.js",
-  "module": "./lib-esm/index.js",
+  "module": "./lib-esm/index.mjs",
   "types": "./lib-types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./lib-esm/index.mjs",
+      "require": "./lib-commonjs/index.js",
+      "types": "./lib-types/index.d.ts"
+    }
+  },
   "files": [
     "lib*/**/*.d.ts",
-    "lib*/**/*.js",
-    "lib*/**/*.js.map",
+    "lib*/**/*.{js,mjs}{,.map}",
     "lib*/**/*.json"
   ],
   "scripts": {


### PR DESCRIPTION
Currently, Node.js always used the CommonJS version even when imported from an ES module. That's because ES modules require an `exports` key to be defined in `package.json`.

(The `module` key is only used by bundlers, AFAIK.)

Also, since there is no `type: "module"` configured, all ES modules need to have the `.mjs` extension (otherwise they will go through the CommonJS compatibility shim which again, will cause the import to fail). Fix that as well.
