### PR TITLE
Support OpenAPI 3.1 `const` value

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,12 +47,11 @@
     "test:ci": "skuba test --coverage",
     "test:watch": "skuba test --watch"
   },
-  "dependencies": {},
   "devDependencies": {
     "@redocly/cli": "1.10.5",
     "@types/node": "^20.3.0",
     "eslint-plugin-zod-openapi": "^0.1.0",
-    "openapi3-ts": "4.2.2",
+    "openapi3-ts": "4.3.1",
     "skuba": "7.5.1",
     "yaml": "2.4.1",
     "zod": "3.22.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,10 +13,10 @@ devDependencies:
     version: 20.4.4
   eslint-plugin-zod-openapi:
     specifier: ^0.1.0
-    version: 0.1.0(eslint@8.36.0)(typescript@5.3.3)
+    version: 0.1.0(eslint@9.0.0)(typescript@5.4.4)
   openapi3-ts:
-    specifier: 4.2.2
-    version: 4.2.2
+    specifier: 4.3.1
+    version: 4.3.1
   skuba:
     specifier: 7.5.1
     version: 7.5.1(@babel/core@7.22.20)
@@ -28,6 +28,11 @@ devDependencies:
     version: 3.22.4
 
 packages:
+
+  /@aashutoshrathi/word-wrap@1.2.6:
+    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /@ampproject/remapping@2.2.0:
     resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
@@ -1642,6 +1647,21 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
+  /@eslint-community/eslint-utils@4.4.0(eslint@9.0.0):
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 9.0.0
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@eslint-community/regexpp@4.10.0:
+    resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
+
   /@eslint-community/regexpp@4.6.2:
     resolution: {integrity: sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
@@ -1664,9 +1684,31 @@ packages:
       - supports-color
     dev: true
 
+  /@eslint/eslintrc@3.0.2:
+    resolution: {integrity: sha512-wV19ZEGEMAC1eHgrS7UQPqsdEiCIbTKTasEfcXAigzoXICcqZSjBZEHlZwNVvKg6UBCjSlos84XiLqsRJnIcIg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4
+      espree: 10.0.1
+      globals: 14.0.0
+      ignore: 5.3.1
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@eslint/js@8.36.0:
     resolution: {integrity: sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@eslint/js@9.0.0:
+    resolution: {integrity: sha512-RThY/MnKrhubF6+s1JflwUjPEsnCEmYCWwqa/aRISKWNXGZ9epUwft4bUMM35SdKF9xvBrLydAM1RDHd1Z//ZQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
   /@exodus/schemasafe@1.0.0:
@@ -1694,6 +1736,17 @@ packages:
       - supports-color
     dev: true
 
+  /@humanwhocodes/config-array@0.12.3:
+    resolution: {integrity: sha512-jsNnTBlMWuTpDkeE3on7+dWJi0D6fdDfeANj/w7MpS8ztROCoLvIO2nG0CcFj+E4k8j4QrSTh4Oryi3i2G669g==}
+    engines: {node: '>=10.10.0'}
+    dependencies:
+      '@humanwhocodes/object-schema': 2.0.3
+      debug: 4.3.4
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@humanwhocodes/module-importer@1.0.1:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
@@ -1701,6 +1754,10 @@ packages:
 
   /@humanwhocodes/object-schema@1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    dev: true
+
+  /@humanwhocodes/object-schema@2.0.3:
+    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     dev: true
 
   /@isaacs/cliui@8.0.2:
@@ -2613,7 +2670,7 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.6.2
-      '@typescript-eslint/parser': 6.21.0(eslint@8.36.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@9.0.0)(typescript@5.4.4)
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/type-utils': 6.21.0(eslint@8.36.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 6.21.0(eslint@8.36.0)(typescript@5.3.3)
@@ -2642,11 +2699,32 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.4)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.4
       eslint: 8.36.0
       typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser@6.21.0(eslint@9.0.0)(typescript@5.4.4):
+    resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.4)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.3.4
+      eslint: 9.0.0
+      typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2718,6 +2796,27 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree@5.59.1(typescript@5.4.4):
+    resolution: {integrity: sha512-lYLBBOCsFltFy7XVqzX0Ju+Lh3WPIAWxYpmH/Q7ZoqzbscLiCW00LeYCdsUnnfnj29/s1WovXKh2gwCoinHNGA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.59.1
+      '@typescript-eslint/visitor-keys': 5.59.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      tsutils: 3.21.0(typescript@5.4.4)
+      typescript: 5.4.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/typescript-estree@6.21.0(typescript@5.3.3):
     resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -2740,6 +2839,28 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree@6.21.0(typescript@5.4.4):
+    resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.0.2(typescript@5.4.4)
+      typescript: 5.4.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/utils@5.59.1(eslint@8.36.0)(typescript@5.3.3):
     resolution: {integrity: sha512-MkTe7FE+K1/GxZkP5gRj3rCztg45bEhsd8HYjczBuYm+qFHP5vtZmjx3B0yUCDotceQ4sHgTyz60Ycl225njmA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2753,6 +2874,26 @@ packages:
       '@typescript-eslint/types': 5.59.1
       '@typescript-eslint/typescript-estree': 5.59.1(typescript@5.3.3)
       eslint: 8.36.0
+      eslint-scope: 5.1.1
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/utils@5.59.1(eslint@9.0.0)(typescript@5.4.4):
+    resolution: {integrity: sha512-MkTe7FE+K1/GxZkP5gRj3rCztg45bEhsd8HYjczBuYm+qFHP5vtZmjx3B0yUCDotceQ4sHgTyz60Ycl225njmA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.0.0)
+      '@types/json-schema': 7.0.12
+      '@types/semver': 7.5.0
+      '@typescript-eslint/scope-manager': 5.59.1
+      '@typescript-eslint/types': 5.59.1
+      '@typescript-eslint/typescript-estree': 5.59.1(typescript@5.4.4)
+      eslint: 9.0.0
       eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
@@ -2810,6 +2951,14 @@ packages:
       event-target-shim: 5.0.1
     dev: true
 
+  /acorn-jsx@5.3.2(acorn@8.11.3):
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.11.3
+    dev: true
+
   /acorn-jsx@5.3.2(acorn@8.8.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2821,6 +2970,12 @@ packages:
   /acorn-walk@8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
+    dev: true
+
+  /acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
     dev: true
 
   /acorn@8.8.2:
@@ -3317,7 +3472,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chownr@2.0.0:
@@ -3986,7 +4141,7 @@ packages:
       eslint: 8.36.0
       eslint-config-prettier: 8.8.0(eslint@8.36.0)
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.21.0)(eslint-plugin-import@2.27.5)(eslint@8.36.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.36.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.21.0)(eslint@9.0.0)
       eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.36.0)(jest@29.5.0)(typescript@5.3.3)
       eslint-plugin-react: 7.32.2(eslint@8.36.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.36.0)
@@ -4008,7 +4163,7 @@ packages:
     dependencies:
       '@types/eslint': 8.21.3
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.36.0)(typescript@5.3.3)
-      '@typescript-eslint/parser': 6.21.0(eslint@8.36.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@9.0.0)(typescript@5.4.4)
       eslint: 8.36.0
       eslint-config-seek: 12.0.1(eslint@8.36.0)(jest@29.5.0)(typescript@5.3.3)
       eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.36.0)(jest@29.5.0)(typescript@5.3.3)
@@ -4043,7 +4198,7 @@ packages:
       enhanced-resolve: 5.15.0
       eslint: 8.36.0
       eslint-module-utils: 2.7.4(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.36.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.36.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.21.0)(eslint@9.0.0)
       get-tsconfig: 4.6.2
       globby: 13.2.2
       is-core-module: 2.13.0
@@ -4086,7 +4241,36 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.36.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.7)(eslint@9.0.0):
+    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@9.0.0)(typescript@5.4.4)
+      debug: 3.2.7
+      eslint: 9.0.0
+      eslint-import-resolver-node: 0.3.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@6.21.0)(eslint@9.0.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4096,15 +4280,15 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.36.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@9.0.0)(typescript@5.4.4)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.36.0
+      eslint: 9.0.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.36.0)
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.7)(eslint@9.0.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -4201,10 +4385,10 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-zod-openapi@0.1.0(eslint@8.36.0)(typescript@5.3.3):
+  /eslint-plugin-zod-openapi@0.1.0(eslint@9.0.0)(typescript@5.4.4):
     resolution: {integrity: sha512-vP5sV0HmwpxcH5TA69pJbVCLPsLpKTtOiPJ68Fejfi3EVrmmI9Y+l8Ao61ujDwjLMKQxN/ycdGWXxMm1lQQK6w==}
     dependencies:
-      '@typescript-eslint/utils': 5.59.1(eslint@8.36.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 5.59.1(eslint@9.0.0)(typescript@5.4.4)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -4227,6 +4411,14 @@ packages:
       estraverse: 5.3.0
     dev: true
 
+  /eslint-scope@8.0.1:
+    resolution: {integrity: sha512-pL8XjgP4ZOmmwfFE8mEhSxA7ZY4C+LWyqjQ3o4yWkkmD0qcMT9kkW3zWHOczhWcjTSgqycYAgwSlXvZltv65og==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+    dev: true
+
   /eslint-visitor-keys@2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
     engines: {node: '>=10'}
@@ -4235,6 +4427,11 @@ packages:
   /eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /eslint-visitor-keys@4.0.0:
+    resolution: {integrity: sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
   /eslint@8.36.0:
@@ -4284,6 +4481,58 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /eslint@9.0.0:
+    resolution: {integrity: sha512-IMryZ5SudxzQvuod6rUdIUz29qFItWx281VhtFVc2Psy/ZhlCeD/5DT6lBIJ4H3G+iamGJoTln1v+QSuPw0p7Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.0.0)
+      '@eslint-community/regexpp': 4.10.0
+      '@eslint/eslintrc': 3.0.2
+      '@eslint/js': 9.0.0
+      '@humanwhocodes/config-array': 0.12.3
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.0.1
+      eslint-visitor-keys: 4.0.0
+      espree: 10.0.1
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.3
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /espree@10.0.1:
+    resolution: {integrity: sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      acorn: 8.11.3
+      acorn-jsx: 5.3.2(acorn@8.11.3)
+      eslint-visitor-keys: 4.0.0
     dev: true
 
   /espree@9.5.0:
@@ -4446,6 +4695,13 @@ packages:
       flat-cache: 3.0.4
     dev: true
 
+  /file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      flat-cache: 4.0.1
+    dev: true
+
   /filelist@1.0.4:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
     dependencies:
@@ -4509,8 +4765,20 @@ packages:
       rimraf: 3.0.2
     dev: true
 
+  /flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+    dependencies:
+      flatted: 3.3.1
+      keyv: 4.5.4
+    dev: true
+
   /flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
+    dev: true
+
+  /flatted@3.3.1:
+    resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
     dev: true
 
   /for-each@0.3.3:
@@ -4578,8 +4846,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -4738,6 +5006,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
+    dev: true
+
+  /globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
     dev: true
 
   /globalthis@1.0.3:
@@ -4964,6 +5237,11 @@ packages:
 
   /ignore@5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
+    engines: {node: '>= 4'}
+    dev: true
+
+  /ignore@5.3.1:
+    resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
     dev: true
 
@@ -5525,7 +5803,7 @@ packages:
       micromatch: 4.0.5
       walker: 1.0.8
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /jest-leak-detector@29.5.0:
@@ -5829,6 +6107,10 @@ packages:
     hasBin: true
     dev: true
 
+  /json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    dev: true
+
   /json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
     dev: true
@@ -5896,6 +6178,12 @@ packages:
     dependencies:
       array-includes: 3.1.6
       object.assign: 4.1.4
+    dev: true
+
+  /keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+    dependencies:
+      json-buffer: 3.0.1
     dev: true
 
   /kind-of@6.0.3:
@@ -6775,8 +7063,8 @@ packages:
       json-pointer: 0.6.2
     dev: true
 
-  /openapi3-ts@4.2.2:
-    resolution: {integrity: sha512-+9g4actZKeb3czfi9gVQ4Br2Ju3KwhCAQJBNaKgye5KggqcBLIhFHH+nIkcm0BUX00TrAJl6dH4JWgM4G4JWrw==}
+  /openapi3-ts@4.3.1:
+    resolution: {integrity: sha512-ha/kTOLhMQL7MvS9Abu/cpCXx5qwHQ++88YkUzn1CGfmM8JvCOG/4ZE6tRsexgXRFaoJrcwLyf81H2Y/CXALtA==}
     dependencies:
       yaml: 2.4.1
     dev: true
@@ -6791,6 +7079,18 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.3
+    dev: true
+
+  /optionator@0.9.3:
+    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      '@aashutoshrathi/word-wrap': 1.2.6
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
     dev: true
 
   /p-each-series@3.0.0:
@@ -8309,6 +8609,15 @@ packages:
       typescript: 5.3.3
     dev: true
 
+  /ts-api-utils@1.0.2(typescript@5.4.4):
+    resolution: {integrity: sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==}
+    engines: {node: '>=16.13.0'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.4.4
+    dev: true
+
   /ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -8458,6 +8767,16 @@ packages:
       typescript: 5.3.3
     dev: true
 
+  /tsutils@3.21.0(typescript@5.4.4):
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 5.4.4
+    dev: true
+
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -8520,6 +8839,12 @@ packages:
 
   /typescript@5.3.3:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
+  /typescript@5.4.4:
+    resolution: {integrity: sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/src/create/document.test.ts
+++ b/src/create/document.test.ts
@@ -341,302 +341,298 @@ describe('createDocument', () => {
     const document = createDocument(complexZodOpenApiObject);
 
     expect(document).toMatchInlineSnapshot(`
-      {
-        "components": {
-          "headers": {
-            "my-header": {
-              "required": true,
-              "schema": {
-                "type": "string",
-              },
-            },
+{
+  "components": {
+    "headers": {
+      "my-header": {
+        "required": true,
+        "schema": {
+          "type": "string",
+        },
+      },
+    },
+    "parameters": {
+      "b": {
+        "in": "path",
+        "name": "b",
+        "required": true,
+        "schema": {
+          "type": "string",
+        },
+      },
+    },
+    "schemas": {
+      "a": {
+        "type": "string",
+      },
+      "b": {
+        "properties": {
+          "a": {
+            "type": "string",
           },
-          "parameters": {
-            "b": {
-              "in": "path",
-              "name": "b",
-              "required": true,
-              "schema": {
-                "type": "string",
-              },
-            },
+        },
+        "required": [
+          "a",
+        ],
+        "type": "object",
+      },
+      "c": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/b",
           },
-          "schemas": {
-            "a": {
-              "type": "string",
+        ],
+        "properties": {
+          "d": {
+            "type": [
+              "string",
+              "null",
+            ],
+          },
+        },
+        "required": [
+          "d",
+        ],
+        "type": "object",
+      },
+      "lazy": {
+        "items": {
+          "$ref": "#/components/schemas/lazy",
+        },
+        "type": "array",
+      },
+      "manual": {
+        "type": "boolean",
+      },
+      "post": {
+        "properties": {
+          "id": {
+            "type": "string",
+          },
+          "user": {
+            "$ref": "#/components/schemas/user",
+          },
+          "userId": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "userId",
+        ],
+        "type": "object",
+      },
+      "union-a": {
+        "properties": {
+          "type": {
+            "const": "a",
+            "type": "string",
+          },
+        },
+        "required": [
+          "type",
+        ],
+        "type": "object",
+      },
+      "union-b": {
+        "properties": {
+          "type": {
+            "const": "b",
+            "type": "string",
+          },
+        },
+        "required": [
+          "type",
+        ],
+        "type": "object",
+      },
+      "user": {
+        "properties": {
+          "id": {
+            "type": "string",
+          },
+          "posts": {
+            "items": {
+              "$ref": "#/components/schemas/post",
             },
-            "b": {
-              "properties": {
-                "a": {
-                  "type": "string",
-                },
-              },
-              "required": [
-                "a",
-              ],
-              "type": "object",
-            },
-            "c": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/b",
-                },
-              ],
-              "properties": {
-                "d": {
-                  "type": [
-                    "string",
-                    "null",
-                  ],
-                },
-              },
-              "required": [
-                "d",
-              ],
-              "type": "object",
-            },
-            "lazy": {
-              "items": {
-                "$ref": "#/components/schemas/lazy",
-              },
-              "type": "array",
-            },
-            "manual": {
-              "type": "boolean",
-            },
-            "post": {
-              "properties": {
-                "id": {
-                  "type": "string",
-                },
-                "user": {
-                  "$ref": "#/components/schemas/user",
-                },
-                "userId": {
-                  "type": "string",
-                },
-              },
-              "required": [
-                "id",
-                "userId",
-              ],
-              "type": "object",
-            },
-            "union-a": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "a",
-                  ],
-                  "type": "string",
-                },
-              },
-              "required": [
-                "type",
-              ],
-              "type": "object",
-            },
-            "union-b": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "b",
-                  ],
-                  "type": "string",
-                },
-              },
-              "required": [
-                "type",
-              ],
-              "type": "object",
-            },
-            "user": {
-              "properties": {
-                "id": {
-                  "type": "string",
-                },
-                "posts": {
-                  "items": {
-                    "$ref": "#/components/schemas/post",
+            "type": "array",
+          },
+        },
+        "required": [
+          "id",
+        ],
+        "type": "object",
+      },
+    },
+  },
+  "info": {
+    "title": "My API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/jobs": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/b",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "a": {
+                    "$ref": "#/components/schemas/a",
                   },
-                  "type": "array",
+                  "b": {
+                    "$ref": "#/components/schemas/b",
+                  },
+                  "c": {
+                    "$ref": "#/components/schemas/b",
+                  },
+                  "d": {
+                    "$ref": "#/components/schemas/c",
+                  },
+                  "e": {
+                    "discriminator": {
+                      "mapping": {
+                        "a": "#/components/schemas/union-a",
+                        "b": "#/components/schemas/union-b",
+                      },
+                      "propertyName": "type",
+                    },
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/union-a",
+                      },
+                      {
+                        "$ref": "#/components/schemas/union-b",
+                      },
+                    ],
+                  },
+                  "f": {
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "prefixItems": [
+                      {
+                        "type": "string",
+                      },
+                      {
+                        "type": "number",
+                      },
+                      {
+                        "$ref": "#/components/schemas/manual",
+                      },
+                    ],
+                    "type": "array",
+                  },
+                  "g": {
+                    "$ref": "#/components/schemas/lazy",
+                  },
+                  "h": {
+                    "$ref": "#/components/schemas/user",
+                  },
                 },
+                "required": [
+                  "a",
+                  "b",
+                  "d",
+                  "e",
+                  "f",
+                  "g",
+                  "h",
+                ],
+                "type": "object",
               },
-              "required": [
-                "id",
-              ],
-              "type": "object",
             },
           },
         },
-        "info": {
-          "title": "My API",
-          "version": "1.0.0",
-        },
-        "openapi": "3.1.0",
-        "paths": {
-          "/jobs": {
-            "get": {
-              "parameters": [
-                {
-                  "$ref": "#/components/parameters/b",
-                },
-              ],
-              "requestBody": {
-                "content": {
-                  "application/json": {
-                    "schema": {
-                      "properties": {
-                        "a": {
-                          "$ref": "#/components/schemas/a",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "a": {
+                      "$ref": "#/components/schemas/a",
+                    },
+                    "b": {
+                      "$ref": "#/components/schemas/b",
+                    },
+                    "c": {
+                      "$ref": "#/components/schemas/b",
+                    },
+                    "d": {
+                      "$ref": "#/components/schemas/c",
+                    },
+                    "e": {
+                      "discriminator": {
+                        "mapping": {
+                          "a": "#/components/schemas/union-a",
+                          "b": "#/components/schemas/union-b",
                         },
-                        "b": {
-                          "$ref": "#/components/schemas/b",
-                        },
-                        "c": {
-                          "$ref": "#/components/schemas/b",
-                        },
-                        "d": {
-                          "$ref": "#/components/schemas/c",
-                        },
-                        "e": {
-                          "discriminator": {
-                            "mapping": {
-                              "a": "#/components/schemas/union-a",
-                              "b": "#/components/schemas/union-b",
-                            },
-                            "propertyName": "type",
-                          },
-                          "oneOf": [
-                            {
-                              "$ref": "#/components/schemas/union-a",
-                            },
-                            {
-                              "$ref": "#/components/schemas/union-b",
-                            },
-                          ],
-                        },
-                        "f": {
-                          "maxItems": 3,
-                          "minItems": 3,
-                          "prefixItems": [
-                            {
-                              "type": "string",
-                            },
-                            {
-                              "type": "number",
-                            },
-                            {
-                              "$ref": "#/components/schemas/manual",
-                            },
-                          ],
-                          "type": "array",
-                        },
-                        "g": {
-                          "$ref": "#/components/schemas/lazy",
-                        },
-                        "h": {
-                          "$ref": "#/components/schemas/user",
-                        },
+                        "propertyName": "type",
                       },
-                      "required": [
-                        "a",
-                        "b",
-                        "d",
-                        "e",
-                        "f",
-                        "g",
-                        "h",
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/union-a",
+                        },
+                        {
+                          "$ref": "#/components/schemas/union-b",
+                        },
                       ],
-                      "type": "object",
+                    },
+                    "f": {
+                      "maxItems": 3,
+                      "minItems": 3,
+                      "prefixItems": [
+                        {
+                          "type": "string",
+                        },
+                        {
+                          "type": "number",
+                        },
+                        {
+                          "$ref": "#/components/schemas/manual",
+                        },
+                      ],
+                      "type": "array",
+                    },
+                    "g": {
+                      "$ref": "#/components/schemas/lazy",
+                    },
+                    "h": {
+                      "$ref": "#/components/schemas/user",
                     },
                   },
+                  "required": [
+                    "a",
+                    "b",
+                    "d",
+                    "e",
+                    "f",
+                    "g",
+                    "h",
+                  ],
+                  "type": "object",
                 },
               },
-              "responses": {
-                "200": {
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "properties": {
-                          "a": {
-                            "$ref": "#/components/schemas/a",
-                          },
-                          "b": {
-                            "$ref": "#/components/schemas/b",
-                          },
-                          "c": {
-                            "$ref": "#/components/schemas/b",
-                          },
-                          "d": {
-                            "$ref": "#/components/schemas/c",
-                          },
-                          "e": {
-                            "discriminator": {
-                              "mapping": {
-                                "a": "#/components/schemas/union-a",
-                                "b": "#/components/schemas/union-b",
-                              },
-                              "propertyName": "type",
-                            },
-                            "oneOf": [
-                              {
-                                "$ref": "#/components/schemas/union-a",
-                              },
-                              {
-                                "$ref": "#/components/schemas/union-b",
-                              },
-                            ],
-                          },
-                          "f": {
-                            "maxItems": 3,
-                            "minItems": 3,
-                            "prefixItems": [
-                              {
-                                "type": "string",
-                              },
-                              {
-                                "type": "number",
-                              },
-                              {
-                                "$ref": "#/components/schemas/manual",
-                              },
-                            ],
-                            "type": "array",
-                          },
-                          "g": {
-                            "$ref": "#/components/schemas/lazy",
-                          },
-                          "h": {
-                            "$ref": "#/components/schemas/user",
-                          },
-                        },
-                        "required": [
-                          "a",
-                          "b",
-                          "d",
-                          "e",
-                          "f",
-                          "g",
-                          "h",
-                        ],
-                        "type": "object",
-                      },
-                    },
-                  },
-                  "description": "200 OK",
-                  "headers": {
-                    "my-header": {
-                      "$ref": "#/components/headers/my-header",
-                    },
-                  },
-                },
+            },
+            "description": "200 OK",
+            "headers": {
+              "my-header": {
+                "$ref": "#/components/headers/my-header",
               },
             },
           },
         },
-      }
-    `);
+      },
+    },
+  },
+}
+`);
   });
 
   it('should generate a complex JSON document string with components in 3.0.0', () => {

--- a/src/create/schema/index.test.ts
+++ b/src/create/schema/index.test.ts
@@ -47,7 +47,7 @@ const expectedZodDiscriminatedUnion: Schema['schema'] = {
       properties: {
         type: {
           type: 'string',
-          enum: ['a'],
+          const: 'a',
         },
       },
       required: ['type'],
@@ -57,7 +57,7 @@ const expectedZodDiscriminatedUnion: Schema['schema'] = {
       properties: {
         type: {
           type: 'string',
-          enum: ['b'],
+          const: 'b',
         },
       },
       required: ['type'],
@@ -86,7 +86,7 @@ const expectedZodIntersection: Schema['schema'] = {
 const zodLiteral = z.literal('a');
 const expectedZodLiteral: Schema['schema'] = {
   type: 'string',
-  enum: ['a'],
+  const: 'a',
 };
 
 const zodMetadata = z.string().openapi({ ref: 'a' });

--- a/src/create/schema/parsers/discriminatedUnion.test.ts
+++ b/src/create/schema/parsers/discriminatedUnion.test.ts
@@ -20,7 +20,7 @@ describe('createDiscriminatedUnionSchema', () => {
             properties: {
               type: {
                 type: 'string',
-                enum: ['a'],
+                const: 'a',
               },
             },
             required: ['type'],
@@ -30,7 +30,7 @@ describe('createDiscriminatedUnionSchema', () => {
             properties: {
               type: {
                 type: 'string',
-                enum: ['b'],
+                const: 'b',
               },
             },
             required: ['type'],

--- a/src/create/schema/parsers/index.ts
+++ b/src/create/schema/parsers/index.ts
@@ -86,7 +86,7 @@ export const createSchemaSwitch = <
   }
 
   if (isZodType(zodSchema, 'ZodNull')) {
-    return createNullSchema(zodSchema);
+    return createNullSchema();
   }
 
   if (isZodType(zodSchema, 'ZodNullable')) {

--- a/src/create/schema/parsers/index.ts
+++ b/src/create/schema/parsers/index.ts
@@ -62,7 +62,7 @@ export const createSchemaSwitch = <
   }
 
   if (isZodType(zodSchema, 'ZodLiteral')) {
-    return createLiteralSchema(zodSchema);
+    return createLiteralSchema(zodSchema, state);
   }
 
   if (isZodType(zodSchema, 'ZodNativeEnum')) {

--- a/src/create/schema/parsers/literal.test.ts
+++ b/src/create/schema/parsers/literal.test.ts
@@ -2,54 +2,143 @@ import { z } from 'zod';
 
 import type { Schema } from '..';
 import { extendZodWithOpenApi } from '../../../extendZod';
+import {
+  createOutputOpenapi3State,
+  createOutputState,
+} from '../../../testing/state';
 
 import { createLiteralSchema } from './literal';
 
 extendZodWithOpenApi(z);
 
 describe('createLiteralSchema', () => {
-  it('creates a string enum schema', () => {
-    const expected: Schema = {
-      type: 'schema',
-      schema: {
-        type: 'string',
-        enum: ['a'],
-      },
-    };
-    const schema = z.literal('a');
+  describe('OpenAPI 3.1.0', () => {
+    it('creates a string const schema', () => {
+      const state = createOutputState();
+      const expected: Schema = {
+        type: 'schema',
+        schema: {
+          type: 'string',
+          const: 'a',
+        },
+      };
+      const schema = z.literal('a');
 
-    const result = createLiteralSchema(schema);
+      const result = createLiteralSchema(schema, state);
 
-    expect(result).toStrictEqual(expected);
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('creates a number const schema', () => {
+      const state = createOutputState();
+      const expected: Schema = {
+        type: 'schema',
+        schema: {
+          type: 'number',
+          const: 2,
+        },
+      };
+      const schema = z.literal(2);
+
+      const result = createLiteralSchema(schema, state);
+
+      expect(result).toEqual(expected);
+    });
+
+    it('creates a boolean const schema', () => {
+      const state = createOutputState();
+      const expected: Schema = {
+        type: 'schema',
+        schema: {
+          type: 'boolean',
+          const: true,
+        },
+      };
+      const schema = z.literal(true);
+
+      const result = createLiteralSchema(schema, state);
+
+      expect(result).toEqual(expected);
+    });
+
+    it('creates a null const schema', () => {
+      const state = createOutputState();
+      const expected: Schema = {
+        type: 'schema',
+        schema: {
+          type: 'null',
+        },
+      };
+      const schema = z.literal(null);
+
+      const result = createLiteralSchema(schema, state);
+
+      expect(result).toEqual(expected);
+    });
   });
 
-  it('creates a number enum schema', () => {
-    const expected: Schema = {
-      type: 'schema',
-      schema: {
-        type: 'number',
-        enum: [2],
-      },
-    };
-    const schema = z.literal(2);
+  describe('OpenAPI 3.0.0', () => {
+    it('creates a string enum schema', () => {
+      const state = createOutputOpenapi3State();
+      const expected: Schema = {
+        type: 'schema',
+        schema: {
+          type: 'string',
+          enum: ['a'],
+        },
+      };
+      const schema = z.literal('a');
 
-    const result = createLiteralSchema(schema);
+      const result = createLiteralSchema(schema, state);
 
-    expect(result).toEqual(expected);
-  });
+      expect(result).toStrictEqual(expected);
+    });
 
-  it('creates a boolean enum schema', () => {
-    const expected: Schema = {
-      type: 'schema',
-      schema: {
-        type: 'boolean',
-        enum: [true],
-      },
-    };
-    const schema = z.literal(true);
+    it('creates a number enum schema', () => {
+      const state = createOutputOpenapi3State();
+      const expected: Schema = {
+        type: 'schema',
+        schema: {
+          type: 'number',
+          enum: [2],
+        },
+      };
+      const schema = z.literal(2);
 
-    const result = createLiteralSchema(schema);
+      const result = createLiteralSchema(schema, state);
 
-    expect(result).toEqual(expected);
+      expect(result).toEqual(expected);
+    });
+
+    it('creates a boolean enum schema', () => {
+      const state = createOutputOpenapi3State();
+      const expected: Schema = {
+        type: 'schema',
+        schema: {
+          type: 'boolean',
+          enum: [true],
+        },
+      };
+      const schema = z.literal(true);
+
+      const result = createLiteralSchema(schema, state);
+
+      expect(result).toEqual(expected);
+    });
+
+    it('creates a null enum schema', () => {
+      const state = createOutputOpenapi3State();
+      const expected: Schema = {
+        type: 'schema',
+        schema: {
+          type: 'null',
+        },
+      };
+      const schema = z.literal(null);
+
+      const result = createLiteralSchema(schema, state);
+
+      expect(result).toEqual(expected);
+    });
   });
 });

--- a/src/create/schema/parsers/literal.ts
+++ b/src/create/schema/parsers/literal.ts
@@ -1,14 +1,38 @@
 import type { ZodLiteral } from 'zod';
 
-import type { Schema } from '..';
+import type { Schema, SchemaState } from '..';
+import { satisfiesVersion } from '../../../openapi';
 import type { oas31 } from '../../../openapi3-ts/dist';
 
 export const createLiteralSchema = (
   zodLiteral: ZodLiteral<unknown>,
-): Schema => ({
-  type: 'schema',
-  schema: {
-    type: typeof zodLiteral.value as oas31.SchemaObject['type'],
-    enum: [zodLiteral._def.value],
-  },
-});
+  state: SchemaState,
+): Schema => {
+  if (satisfiesVersion(state.components.openapi, '3.1.0')) {
+    return {
+      type: 'schema',
+      schema: {
+        type: resolveLiteralType(zodLiteral.value),
+        const: zodLiteral._def.value,
+      },
+    };
+  }
+
+  return {
+    type: 'schema',
+    schema: {
+      type: resolveLiteralType(zodLiteral.value),
+      enum: [zodLiteral._def.value],
+    },
+  };
+};
+
+export const resolveLiteralType = (
+  value: unknown,
+): oas31.SchemaObject['type'] => {
+  if (value === null) {
+    return 'null';
+  }
+
+  return typeof value as oas31.SchemaObject['type'],
+};

--- a/src/create/schema/parsers/null.test.ts
+++ b/src/create/schema/parsers/null.test.ts
@@ -15,9 +15,8 @@ describe('createNullSchema', () => {
         type: 'null',
       },
     };
-    const schema = z.null();
 
-    const result = createNullSchema(schema);
+    const result = createNullSchema();
 
     expect(result).toEqual(expected);
   });

--- a/src/create/schema/parsers/null.ts
+++ b/src/create/schema/parsers/null.ts
@@ -1,8 +1,6 @@
-import type { ZodNull } from 'zod';
-
 import type { Schema } from '..';
 
-export const createNullSchema = (_zodNull: ZodNull): Schema => ({
+export const createNullSchema = (): Schema => ({
   type: 'schema',
   schema: {
     type: 'null',

--- a/src/create/schema/parsers/optional.test.ts
+++ b/src/create/schema/parsers/optional.test.ts
@@ -166,4 +166,28 @@ describe('isOptionalSchema', () => {
 
     expect(result).toEqual({ optional: false });
   });
+
+  it('returns true for zod undefined', () => {
+    const schema = z.undefined();
+
+    const result = isOptionalSchema(schema, createOutputState());
+
+    expect(result).toEqual({ optional: true });
+  });
+
+  it('returns true for zod never', () => {
+    const schema = z.never();
+
+    const result = isOptionalSchema(schema, createOutputState());
+
+    expect(result).toEqual({ optional: true });
+  });
+
+  it('returns true for zod literal undefined', () => {
+    const schema = z.literal(undefined);
+
+    const result = isOptionalSchema(schema, createOutputState());
+
+    expect(result).toEqual({ optional: true });
+  });
 });

--- a/src/create/schema/parsers/optional.ts
+++ b/src/create/schema/parsers/optional.ts
@@ -24,7 +24,8 @@ export const isOptionalSchema = (
   if (
     isZodType(zodSchema, 'ZodOptional') ||
     isZodType(zodSchema, 'ZodNever') ||
-    isZodType(zodSchema, 'ZodUndefined')
+    isZodType(zodSchema, 'ZodUndefined') ||
+    (isZodType(zodSchema, 'ZodLiteral') && zodSchema._def.value === undefined)
   ) {
     return { optional: true };
   }

--- a/src/openapi3-ts/dist/model/openapi31.ts
+++ b/src/openapi3-ts/dist/model/openapi31.ts
@@ -232,6 +232,7 @@ export interface SchemaObject extends ISpecificationExtension {
     title?: string;
     multipleOf?: number;
     maximum?: number;
+    const?: any;
     exclusiveMaximum?: number;
     minimum?: number;
     exclusiveMinimum?: number;


### PR DESCRIPTION
ZodLiteral values will now be represented using the [const](https://json-schema.org/understanding-json-schema/reference/const#constant-values) keyword instead of a single value enum.

The following object, this will be now rendered as follows in OpenAPI 3.1

```ts
z.object({
  foo: z.literal('foo')
});
```

```diff
 foo:
   type: 'string'
-  enum:
-    - 'foo'
+  const: 'foo'
```
