### PR TITLE
Move api import to subpath

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -15,3 +15,4 @@ node_modules*/
 # end managed by skuba
 
 src/openapi3-ts/*
+crackle.config.ts

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ yarn-error.log
 # end managed by skuba
 
 # managed by crackle
+/api
 /dist
 /extend
 # end managed by crackle

--- a/crackle.config.ts
+++ b/crackle.config.ts
@@ -1,0 +1,7 @@
+import type { UserConfig } from '@crackle/cli/config';
+
+export default {
+  dts: {
+    mode: 'preserve',
+  },
+} satisfies UserConfig;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,14 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
+    "./api": {
+      "types": {
+        "import": "./dist/api.d.mts",
+        "require": "./dist/api.d.ts"
+      },
+      "import": "./dist/api.mjs",
+      "require": "./dist/api.cjs"
+    },
     "./extend": {
       "types": {
         "import": "./dist/extend.d.mts",
@@ -48,6 +56,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
+    "api",
     "dist",
     "extend"
   ],

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,0 @@
-export {
-  createComponents,
-  getDefaultComponents,
-  type ComponentsObject,
-} from './create/components';
-export { createMediaTypeSchema } from './create/content';
-export { createParamOrRef } from './create/parameters';

--- a/src/entries/api.ts
+++ b/src/entries/api.ts
@@ -1,0 +1,7 @@
+export {
+  createComponents,
+  getDefaultComponents,
+  type ComponentsObject,
+} from '../create/components';
+export { createMediaTypeSchema } from '../create/content';
+export { createParamOrRef } from '../create/parameters';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
 export * from './create/document';
 export * from './extendZod';
 export * from './openapi3-ts/dist';
-export * as api from './api';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,6 @@
     "removeComments": false,
     "target": "ES2022"
   },
-  "exclude": ["lib*/**/*"],
+  "exclude": ["lib*/**/*", "crackle.config.ts"],
   "extends": "skuba/config/tsconfig.json"
 }


### PR DESCRIPTION
The `api` export was only ever intended for plugin/integration access however in Intellisense it appears as one of the first options. This moves it to a subpath import so the main functionality is clearer upon import. This moves it to under `zod-openapi/api`

