### PR TITLE
Add default date schema option

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ const document = createDocument({
   ```
 </details>
 
+`createDocument` takes an optional `CreateDocumentOptions` argument which can be used to modify how the document is created.
+
+```typescript
+const document = createDocument(details, {
+  defaultDateSchema: { type: 'string', format: 'date-time' }, // defaults to { type: 'string' }
+});
+```
+
 ### Request Parameters
 
 Query, Path, Header & Cookie parameters can be created using the `requestParams` key under the `method` key as follows:

--- a/src/create/callbacks.ts
+++ b/src/create/callbacks.ts
@@ -4,7 +4,10 @@ import {
   type ComponentsObject,
   createComponentCallbackRef,
 } from './components';
-import type { ZodOpenApiCallbackObject } from './document';
+import type {
+  CreateDocumentOptions,
+  ZodOpenApiCallbackObject,
+} from './document';
 import { createPathItem } from './paths';
 import { isISpecificationExtension } from './specificationExtension';
 
@@ -12,6 +15,7 @@ export const createCallback = (
   callbackObject: ZodOpenApiCallbackObject,
   components: ComponentsObject,
   subpath: string[],
+  documentOptions?: CreateDocumentOptions,
 ): oas31.CallbackObject => {
   const { ref, ...callbacks } = callbackObject;
 
@@ -24,11 +28,13 @@ export const createCallback = (
       return acc;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    acc[callbackName] = createPathItem(pathItemObject, components, [
-      ...subpath,
-      callbackName,
-    ]);
+    acc[callbackName] = createPathItem(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      pathItemObject,
+      components,
+      [...subpath, callbackName],
+      documentOptions,
+    );
     return acc;
   }, {});
 
@@ -50,6 +56,7 @@ export const createCallbacks = (
   callbacksObject: oas31.CallbackObject | undefined,
   components: ComponentsObject,
   subpath: string[],
+  documentOptions?: CreateDocumentOptions,
 ): oas31.CallbackObject | undefined => {
   if (!callbacksObject) {
     return undefined;
@@ -61,11 +68,14 @@ export const createCallbacks = (
         acc[callbackName] = callbackObject;
         return acc;
       }
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      acc[callbackName] = createCallback(callbackObject, components, [
-        ...subpath,
-        callbackName,
-      ]);
+
+      acc[callbackName] = createCallback(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        callbackObject,
+        components,
+        [...subpath, callbackName],
+        documentOptions,
+      );
       return acc;
     },
     {},

--- a/src/create/components.ts
+++ b/src/create/components.ts
@@ -5,6 +5,7 @@ import { isAnyZodType } from '../zodType';
 
 import { createCallback } from './callbacks';
 import type {
+  CreateDocumentOptions,
   ZodOpenApiCallbackObject,
   ZodOpenApiComponentsObject,
   ZodOpenApiRequestBodyObject,
@@ -399,16 +400,35 @@ export const createComponentCallbackRef = (callbackRef: string) =>
 export const createComponents = (
   componentsObject: ZodOpenApiComponentsObject,
   components: ComponentsObject,
+  documentOptions?: CreateDocumentOptions,
 ): oas31.ComponentsObject | undefined => {
-  const combinedSchemas = createSchemaComponents(componentsObject, components);
+  const combinedSchemas = createSchemaComponents(
+    componentsObject,
+    components,
+    documentOptions,
+  );
   const combinedParameters = createParamComponents(
     componentsObject,
     components,
+    documentOptions,
   );
-  const combinedHeaders = createHeaderComponents(componentsObject, components);
-  const combinedResponses = createResponseComponents(components);
-  const combinedRequestBodies = createRequestBodiesComponents(components);
-  const combinedCallbacks = createCallbackComponents(components);
+  const combinedHeaders = createHeaderComponents(
+    componentsObject,
+    components,
+    documentOptions,
+  );
+  const combinedResponses = createResponseComponents(
+    components,
+    documentOptions,
+  );
+  const combinedRequestBodies = createRequestBodiesComponents(
+    components,
+    documentOptions,
+  );
+  const combinedCallbacks = createCallbackComponents(
+    components,
+    documentOptions,
+  );
 
   const { schemas, parameters, headers, responses, requestBodies, ...rest } =
     componentsObject;
@@ -428,6 +448,7 @@ export const createComponents = (
 const createSchemaComponents = (
   componentsObject: ZodOpenApiComponentsObject,
   components: ComponentsObject,
+  documentOptions?: CreateDocumentOptions,
 ): oas31.ComponentsObject['schemas'] => {
   Array.from(components.schemas).forEach(([schema, { type }], index) => {
     if (type === 'manual') {
@@ -436,6 +457,7 @@ const createSchemaComponents = (
         type: schema._def.openapi?.refType ?? 'output',
         path: [],
         visited: new Set(),
+        documentOptions,
       };
 
       createSchema(schema, state, [`component schema index ${index}`]);
@@ -479,6 +501,7 @@ const createSchemaComponents = (
 const createParamComponents = (
   componentsObject: ZodOpenApiComponentsObject,
   components: ComponentsObject,
+  documentOptions?: CreateDocumentOptions,
 ): oas31.ComponentsObject['parameters'] => {
   Array.from(components.parameters).forEach(([schema, component], index) => {
     if (component.type === 'manual') {
@@ -486,6 +509,7 @@ const createParamComponents = (
         schema,
         components,
         [`component parameter index ${index}`],
+        documentOptions,
         component.in,
         component.ref,
       );
@@ -527,10 +551,11 @@ const createParamComponents = (
 const createHeaderComponents = (
   componentsObject: ZodOpenApiComponentsObject,
   components: ComponentsObject,
+  documentOptions?: CreateDocumentOptions,
 ): oas31.ComponentsObject['headers'] => {
   Array.from(components.headers).forEach(([schema, component]) => {
     if (component.type === 'manual') {
-      createHeaderOrRef(schema, components);
+      createHeaderOrRef(schema, components, documentOptions);
     }
   });
 
@@ -566,10 +591,16 @@ const createHeaderComponents = (
 
 const createResponseComponents = (
   components: ComponentsObject,
+  documentOptions?: CreateDocumentOptions,
 ): oas31.ComponentsObject['responses'] => {
   Array.from(components.responses).forEach(([schema, component], index) => {
     if (component.type === 'manual') {
-      createResponse(schema, components, [`component response index ${index}`]);
+      createResponse(
+        schema,
+        components,
+        [`component response index ${index}`],
+        documentOptions,
+      );
     }
   });
 
@@ -591,12 +622,16 @@ const createResponseComponents = (
 
 const createRequestBodiesComponents = (
   components: ComponentsObject,
+  documentOptions?: CreateDocumentOptions,
 ): oas31.ComponentsObject['requestBodies'] => {
   Array.from(components.requestBodies).forEach(([schema, component], index) => {
     if (component.type === 'manual') {
-      createRequestBody(schema, components, [
-        `component request body ${index}`,
-      ]);
+      createRequestBody(
+        schema,
+        components,
+        [`component request body ${index}`],
+        documentOptions,
+      );
     }
   });
 
@@ -619,10 +654,16 @@ const createRequestBodiesComponents = (
 
 const createCallbackComponents = (
   components: ComponentsObject,
+  documentOptions?: CreateDocumentOptions,
 ): oas31.ComponentsObject['callbacks'] => {
   Array.from(components.callbacks).forEach(([schema, component], index) => {
     if (component.type === 'manual') {
-      createCallback(schema, components, [`component callback ${index}`]);
+      createCallback(
+        schema,
+        components,
+        [`component callback ${index}`],
+        documentOptions,
+      );
     }
   });
 

--- a/src/create/content.ts
+++ b/src/create/content.ts
@@ -5,6 +5,7 @@ import { isAnyZodType } from '../zodType';
 
 import type { ComponentsObject, CreationType } from './components';
 import type {
+  CreateDocumentOptions,
   ZodOpenApiContentObject,
   ZodOpenApiMediaTypeObject,
 } from './document';
@@ -19,6 +20,7 @@ export const createMediaTypeSchema = (
   components: ComponentsObject,
   type: CreationType,
   subpath: string[],
+  documentOptions?: CreateDocumentOptions,
 ): oas31.SchemaObject | oas31.ReferenceObject | undefined => {
   if (!schemaObject) {
     return undefined;
@@ -35,6 +37,7 @@ export const createMediaTypeSchema = (
       type,
       path: [],
       visited: new Set(),
+      documentOptions,
     },
     subpath,
   );
@@ -45,6 +48,7 @@ const createMediaTypeObject = (
   components: ComponentsObject,
   type: CreationType,
   subpath: string[],
+  documentOptions?: CreateDocumentOptions,
 ): oas31.MediaTypeObject | undefined => {
   if (!mediaTypeObject) {
     return undefined;
@@ -52,10 +56,13 @@ const createMediaTypeObject = (
 
   return {
     ...mediaTypeObject,
-    schema: createMediaTypeSchema(mediaTypeObject.schema, components, type, [
-      ...subpath,
-      'schema',
-    ]),
+    schema: createMediaTypeSchema(
+      mediaTypeObject.schema,
+      components,
+      type,
+      [...subpath, 'schema'],
+      documentOptions,
+    ),
   };
 };
 
@@ -64,6 +71,7 @@ export const createContent = (
   components: ComponentsObject,
   type: CreationType,
   subpath: string[],
+  documentOptions?: CreateDocumentOptions,
 ): oas31.ContentObject =>
   Object.entries(contentObject).reduce<oas31.ContentObject>(
     (acc, [mediaType, zodOpenApiMediaTypeObject]): oas31.ContentObject => {
@@ -72,6 +80,7 @@ export const createContent = (
         components,
         type,
         [...subpath, mediaType],
+        documentOptions,
       );
 
       if (mediaTypeObject) {

--- a/src/create/document.test.ts
+++ b/src/create/document.test.ts
@@ -2,6 +2,7 @@ import '../entries/extend';
 import { type ZodType, z } from 'zod';
 
 import {
+  type CreateDocumentOptions,
   type ZodOpenApiCallbackObject,
   type ZodOpenApiObject,
   createDocument,
@@ -1378,6 +1379,246 @@ describe('createDocument', () => {
                     },
                   },
                   "description": "200 OK",
+                },
+              },
+            },
+          },
+        },
+      }
+    `);
+  });
+
+  it('Supports defaultDateSchema option', () => {
+    const UserSchema = z.object({
+      id: z.string(),
+      timestamp: z.date(),
+    });
+
+    const documentOptions: CreateDocumentOptions = {
+      defaultDateSchema: {
+        type: 'string',
+        format: 'date-time',
+      },
+    };
+
+    const document = createDocument(
+      {
+        info: {
+          title: 'My API',
+          version: '1.0.0',
+        },
+        openapi: '3.1.0',
+        components: {
+          schemas: {
+            User: UserSchema,
+          },
+        },
+        paths: {
+          '/timestamp/:timestamp': {
+            post: {
+              parameters: [
+                z.date().openapi({
+                  param: {
+                    in: 'path',
+                    name: 'timestamp',
+                    required: true,
+                  },
+                }),
+              ],
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: z.object({
+                      timestamp: z.date(),
+                    }),
+                  },
+                },
+              },
+              responses: {
+                '200': {
+                  description: '200 OK',
+                  headers: z.object({
+                    timeStamp: z.date(),
+                  }),
+                  content: {
+                    'application/json': {
+                      schema: z.object({
+                        timestamp: z.date(),
+                      }),
+                    },
+                  },
+                },
+              },
+              callbacks: {
+                onData: {
+                  '{$request.query.callbackUrl}/data': {
+                    post: {
+                      requestBody: {
+                        content: {
+                          'application/json': {
+                            schema: z.object({
+                              timestamp: z.date(),
+                            }),
+                          },
+                        },
+                      },
+                      responses: {
+                        '202': {
+                          description: '200 OK',
+                          content: {
+                            'application/json': {
+                              schema: z.object({
+                                timestamp: z.date(),
+                              }),
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      documentOptions,
+    );
+
+    expect(document).toMatchInlineSnapshot(`
+      {
+        "components": {
+          "schemas": {
+            "User": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                },
+                "timestamp": {
+                  "format": "date-time",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "id",
+                "timestamp",
+              ],
+              "type": "object",
+            },
+          },
+        },
+        "info": {
+          "title": "My API",
+          "version": "1.0.0",
+        },
+        "openapi": "3.1.0",
+        "paths": {
+          "/timestamp/:timestamp": {
+            "post": {
+              "callbacks": {
+                "onData": {
+                  "{$request.query.callbackUrl}/data": {
+                    "post": {
+                      "requestBody": {
+                        "content": {
+                          "application/json": {
+                            "schema": {
+                              "properties": {
+                                "timestamp": {
+                                  "format": "date-time",
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "timestamp",
+                              ],
+                              "type": "object",
+                            },
+                          },
+                        },
+                      },
+                      "responses": {
+                        "202": {
+                          "content": {
+                            "application/json": {
+                              "schema": {
+                                "properties": {
+                                  "timestamp": {
+                                    "format": "date-time",
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "timestamp",
+                                ],
+                                "type": "object",
+                              },
+                            },
+                          },
+                          "description": "200 OK",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              "parameters": [
+                {
+                  "in": "path",
+                  "name": "timestamp",
+                  "required": true,
+                  "schema": {
+                    "format": "date-time",
+                    "type": "string",
+                  },
+                },
+              ],
+              "requestBody": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "properties": {
+                        "timestamp": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "timestamp",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                },
+              },
+              "responses": {
+                "200": {
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "properties": {
+                          "timestamp": {
+                            "format": "date-time",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "timestamp",
+                        ],
+                        "type": "object",
+                      },
+                    },
+                  },
+                  "description": "200 OK",
+                  "headers": {
+                    "timeStamp": {
+                      "required": true,
+                      "schema": {
+                        "format": "date-time",
+                        "type": "string",
+                      },
+                    },
+                  },
                 },
               },
             },

--- a/src/create/document.ts
+++ b/src/create/document.ts
@@ -154,8 +154,13 @@ export type ZodObjectInputType<
   Input = Record<string, unknown>,
 > = ZodType<Output, Def, Input>;
 
+export interface CreateDocumentOptions {
+  defaultDateSchema?: Pick<oas31.SchemaObject, 'type' | 'format'>;
+}
+
 export const createDocument = (
   zodOpenApiObject: ZodOpenApiObject,
+  documentOptions?: CreateDocumentOptions,
 ): oas31.OpenAPIObject => {
   const { paths, webhooks, components = {}, ...rest } = zodOpenApiObject;
   const defaultComponents = getDefaultComponents(
@@ -163,9 +168,17 @@ export const createDocument = (
     zodOpenApiObject.openapi,
   );
 
-  const createdPaths = createPaths(paths, defaultComponents);
-  const createdWebhooks = createPaths(webhooks, defaultComponents);
-  const createdComponents = createComponents(components, defaultComponents);
+  const createdPaths = createPaths(paths, defaultComponents, documentOptions);
+  const createdWebhooks = createPaths(
+    webhooks,
+    defaultComponents,
+    documentOptions,
+  );
+  const createdComponents = createComponents(
+    components,
+    defaultComponents,
+    documentOptions,
+  );
 
   return {
     ...rest,

--- a/src/create/paths.ts
+++ b/src/create/paths.ts
@@ -7,6 +7,7 @@ import {
 } from './components';
 import { createContent } from './content';
 import type {
+  CreateDocumentOptions,
   ZodOpenApiOperationObject,
   ZodOpenApiPathItemObject,
   ZodOpenApiPathsObject,
@@ -20,6 +21,7 @@ export const createRequestBody = (
   requestBodyObject: ZodOpenApiRequestBodyObject | undefined,
   components: ComponentsObject,
   subpath: string[],
+  documentOptions?: CreateDocumentOptions,
 ): oas31.ReferenceObject | oas31.RequestBodyObject | undefined => {
   if (!requestBodyObject) {
     return undefined;
@@ -36,10 +38,13 @@ export const createRequestBody = (
 
   const requestBody: oas31.RequestBodyObject = {
     ...requestBodyObject,
-    content: createContent(requestBodyObject.content, components, 'input', [
-      ...subpath,
-      'content',
-    ]),
+    content: createContent(
+      requestBodyObject.content,
+      components,
+      'input',
+      [...subpath, 'content'],
+      documentOptions,
+    ),
   };
 
   if (ref) {
@@ -60,6 +65,7 @@ const createOperation = (
   operationObject: ZodOpenApiOperationObject,
   components: ComponentsObject,
   subpath: string[],
+  documentOptions?: CreateDocumentOptions,
 ): oas31.OperationObject | undefined => {
   const { parameters, requestParams, requestBody, responses, ...rest } =
     operationObject;
@@ -69,24 +75,28 @@ const createOperation = (
     requestParams,
     components,
     [...subpath, 'parameters'],
+    documentOptions,
   );
 
   const maybeRequestBody = createRequestBody(
     operationObject.requestBody,
     components,
     [...subpath, 'request body'],
+    documentOptions,
   );
 
   const maybeResponses = createResponses(
     operationObject.responses,
     components,
     [...subpath, 'responses'],
+    documentOptions,
   );
 
   const maybeCallbacks = createCallbacks(
     operationObject.callbacks,
     components,
     [...subpath, 'callbacks'],
+    documentOptions,
   );
 
   return {
@@ -102,6 +112,7 @@ export const createPathItem = (
   pathObject: ZodOpenApiPathItemObject,
   components: ComponentsObject,
   path: string[],
+  documentOptions?: CreateDocumentOptions,
 ): oas31.PathItemObject =>
   Object.entries(pathObject).reduce<oas31.PathItemObject>(
     (acc, [key, value]) => {
@@ -123,6 +134,7 @@ export const createPathItem = (
           value as ZodOpenApiOperationObject,
           components,
           [...path, key],
+          documentOptions,
         );
         return acc;
       }
@@ -137,6 +149,7 @@ export const createPathItem = (
 export const createPaths = (
   pathsObject: ZodOpenApiPathsObject | undefined,
   components: ComponentsObject,
+  documentOptions?: CreateDocumentOptions,
 ): oas31.PathsObject | undefined => {
   if (!pathsObject) {
     return undefined;
@@ -148,7 +161,12 @@ export const createPaths = (
         acc[path] = pathItemObject;
         return acc;
       }
-      acc[path] = createPathItem(pathItemObject, components, [path]);
+      acc[path] = createPathItem(
+        pathItemObject,
+        components,
+        [path],
+        documentOptions,
+      );
       return acc;
     },
     {},

--- a/src/create/schema/index.ts
+++ b/src/create/schema/index.ts
@@ -8,6 +8,7 @@ import {
   type SchemaComponent,
   createComponentSchemaRef,
 } from '../components';
+import type { CreateDocumentOptions } from '../document';
 
 import { enhanceWithMetadata } from './metadata';
 import { createSchemaSwitch } from './parsers';
@@ -20,6 +21,7 @@ export interface SchemaState {
   type: CreationType;
   path: string[];
   visited: Set<ZodType>;
+  documentOptions?: CreateDocumentOptions;
 }
 
 const isDescriptionEqual = (schema: Schema, zodSchema: ZodType): boolean =>

--- a/src/create/schema/parsers/date.test.ts
+++ b/src/create/schema/parsers/date.test.ts
@@ -2,6 +2,8 @@ import '../../../entries/extend';
 import { z } from 'zod';
 
 import type { Schema } from '..';
+import { createOutputState } from '../../../testing/state';
+import type { CreateDocumentOptions } from '../../document';
 
 import { createDateSchema } from './date';
 
@@ -15,7 +17,53 @@ describe('createDateSchema', () => {
     };
     const schema = z.date();
 
-    const result = createDateSchema(schema);
+    const result = createDateSchema(schema, createOutputState());
+
+    expect(result).toEqual(expected);
+  });
+
+  it('sets a custom format', () => {
+    const expected: Schema = {
+      type: 'schema',
+      schema: {
+        type: 'string',
+        format: 'date-time',
+      },
+    };
+    const schema = z.date();
+    const documentOptions: CreateDocumentOptions = {
+      defaultDateSchema: {
+        type: 'string',
+        format: 'date-time',
+      },
+    };
+
+    const result = createDateSchema(
+      schema,
+      createOutputState(undefined, documentOptions),
+    );
+
+    expect(result).toEqual(expected);
+  });
+
+  it('sets a custom type', () => {
+    const expected: Schema = {
+      type: 'schema',
+      schema: {
+        type: 'number',
+      },
+    };
+    const schema = z.date();
+    const documentOptions: CreateDocumentOptions = {
+      defaultDateSchema: {
+        type: 'number',
+      },
+    };
+
+    const result = createDateSchema(
+      schema,
+      createOutputState(undefined, documentOptions),
+    );
 
     expect(result).toEqual(expected);
   });

--- a/src/create/schema/parsers/date.ts
+++ b/src/create/schema/parsers/date.ts
@@ -1,10 +1,13 @@
 import type { ZodDate } from 'zod';
 
-import type { Schema } from '..';
+import type { Schema, SchemaState } from '..';
 
-export const createDateSchema = (_zodDate: ZodDate): Schema => ({
+export const createDateSchema = (
+  _zodDate: ZodDate,
+  state: SchemaState,
+): Schema => ({
   type: 'schema',
-  schema: {
+  schema: state.documentOptions?.defaultDateSchema ?? {
     type: 'string',
   },
 });

--- a/src/create/schema/parsers/index.ts
+++ b/src/create/schema/parsers/index.ts
@@ -114,7 +114,7 @@ export const createSchemaSwitch = <
   }
 
   if (isZodType(zodSchema, 'ZodDate')) {
-    return createDateSchema(zodSchema);
+    return createDateSchema(zodSchema, state);
   }
 
   if (isZodType(zodSchema, 'ZodPipeline')) {

--- a/src/testing/state.ts
+++ b/src/testing/state.ts
@@ -1,14 +1,19 @@
 import { getDefaultComponents } from '../create/components';
-import type { ZodOpenApiComponentsObject } from '../create/document';
+import type {
+  CreateDocumentOptions,
+  ZodOpenApiComponentsObject,
+} from '../create/document';
 import type { SchemaState } from '../create/schema';
 
 export const createOutputState = (
   componentsObject?: ZodOpenApiComponentsObject,
+  documentOptions?: CreateDocumentOptions,
 ): SchemaState => ({
   components: getDefaultComponents(componentsObject),
   type: 'output',
   path: [],
   visited: new Set(),
+  documentOptions,
 });
 
 export const createInputState = (


### PR DESCRIPTION
closed https://github.com/samchungy/zod-openapi/issues/305

Hi samchungy.

I have added a feature that resolves #305.

Added an options object argument to createDocument function to allow setting the value of  `defaultDateSchema`.
After the SchemaState object is created, it is passed to each function by passing an options object to SchemaState object.

If you see any problems or shortcomings, please point them out to me.