### PR TITLE
`.openapi()` Breaking Change

### DIFF
--- a/src/create/components.ts
+++ b/src/create/components.ts
@@ -254,7 +254,7 @@ const getSchemas = (
           `Schema ${JSON.stringify(schema._def)} is already registered`,
         );
       }
-      const ref = schema._def.openapi?.ref ?? key;
+      const ref = schema._def.zodOpenApi?.openapi?.ref ?? key;
       components.schemas.set(schema, {
         type: 'manual',
         ref,
@@ -278,9 +278,9 @@ const getParameters = (
           `Parameter ${JSON.stringify(schema._def)} is already registered`,
         );
       }
-      const ref = schema._def.openapi?.param?.ref ?? key;
-      const name = schema._def.openapi?.param?.name;
-      const location = schema._def.openapi?.param?.in;
+      const ref = schema._def.zodOpenApi?.openapi?.param?.ref ?? key;
+      const name = schema._def.zodOpenApi?.openapi?.param?.name;
+      const location = schema._def.zodOpenApi?.openapi?.param?.in;
 
       if (!name || !location) {
         throw new Error('`name` or `in` missing in .openapi()');
@@ -310,7 +310,7 @@ const getHeaders = (
           `Header ${JSON.stringify(schema._def)} is already registered`,
         );
       }
-      const ref = schema._def.openapi?.param?.ref ?? key;
+      const ref = schema._def.zodOpenApi?.openapi?.param?.ref ?? key;
       components.headers.set(schema, {
         type: 'manual',
         ref,
@@ -456,7 +456,7 @@ export const createSchemaComponents = (
     if (type === 'manual') {
       const state: SchemaState = {
         components,
-        type: schema._def.openapi?.refType ?? 'output',
+        type: schema._def.zodOpenApi?.openapi?.refType ?? 'output',
         path: [],
         visited: new Set(),
         documentOptions,

--- a/src/create/document.test.ts
+++ b/src/create/document.test.ts
@@ -518,7 +518,6 @@ describe('createDocument', () => {
         "required": [
           "d",
         ],
-        "type": "object",
       },
       "lazy": {
         "items": {
@@ -852,7 +851,6 @@ describe('createDocument', () => {
         "required": [
           "d",
         ],
-        "type": "object",
       },
       "lazy": {
         "items": {

--- a/src/create/parameters.test.ts
+++ b/src/create/parameters.test.ts
@@ -249,7 +249,6 @@ describe('createParametersObject', () => {
     const expectedResult: oas31.BaseParameterObject = {
       schema: {
         type: 'string',
-        description: 'foo',
       },
       description: 'boo',
       required: true,

--- a/src/create/parameters.test.ts
+++ b/src/create/parameters.test.ts
@@ -249,6 +249,7 @@ describe('createParametersObject', () => {
     const expectedResult: oas31.BaseParameterObject = {
       schema: {
         type: 'string',
+        description: 'foo',
       },
       description: 'boo',
       required: true,

--- a/src/create/parameters.ts
+++ b/src/create/parameters.ts
@@ -20,7 +20,7 @@ export const createBaseParameter = (
   subpath: string[],
   documentOptions?: CreateDocumentOptions,
 ): oas31.BaseParameterObject => {
-  const { ref, ...rest } = schema._def.openapi?.param ?? {};
+  const { ref, ...rest } = schema._def.zodOpenApi?.openapi?.param ?? {};
   const state: SchemaState = {
     components,
     type: 'input',
@@ -32,7 +32,7 @@ export const createBaseParameter = (
   const required = !schema.isOptional();
 
   const description =
-    schema._def.openapi?.description ?? schema._def.description;
+    schema._def.zodOpenApi?.openapi?.description ?? schema._def.description;
 
   return {
     ...(description && { description }),
@@ -51,9 +51,10 @@ export const createParamOrRef = (
   documentOptions?: CreateDocumentOptions,
 ): oas31.ParameterObject | oas31.ReferenceObject => {
   const component = components.parameters.get(zodSchema);
-  const paramType = zodSchema._def?.openapi?.param?.in ?? component?.in ?? type;
+  const paramType =
+    zodSchema._def.zodOpenApi?.openapi?.param?.in ?? component?.in ?? type;
   const paramName =
-    zodSchema._def?.openapi?.param?.name ?? component?.name ?? name;
+    zodSchema._def.zodOpenApi?.openapi?.param?.name ?? component?.name ?? name;
 
   if (!paramType) {
     throw new Error('Parameter type missing');
@@ -86,7 +87,7 @@ export const createParamOrRef = (
     throw new Error('Unexpected Error: received a reference object');
   }
 
-  const ref = zodSchema?._def?.openapi?.param?.ref ?? component?.ref;
+  const ref = zodSchema?._def.zodOpenApi?.openapi?.param?.ref ?? component?.ref;
 
   const paramObject: oas31.ParameterObject = {
     in: paramType,

--- a/src/create/responses.ts
+++ b/src/create/responses.ts
@@ -59,7 +59,7 @@ export const createHeaderOrRef = (
     throw new Error('Unexpected Error: received a reference object');
   }
 
-  const ref = schema._def?.openapi?.header?.ref ?? component?.ref;
+  const ref = schema._def.zodOpenApi?.openapi?.header?.ref ?? component?.ref;
 
   if (ref) {
     components.headers.set(schema, {
@@ -80,7 +80,7 @@ export const createBaseHeader = (
   components: ComponentsObject,
   documentOptions?: CreateDocumentOptions,
 ): oas31.BaseParameterObject => {
-  const { ref, ...rest } = schema._def.openapi?.header ?? {};
+  const { ref, ...rest } = schema._def.zodOpenApi?.openapi?.header ?? {};
   const state: SchemaState = {
     components,
     type: 'output',

--- a/src/create/schema/index.ts
+++ b/src/create/schema/index.ts
@@ -220,11 +220,11 @@ export const createSchemaOrRef = <
     return existingRef;
   }
 
-  const previous =
-    zodSchema._def.zodOpenApi?.previous &&
-    (createSchemaOrRef(zodSchema._def.zodOpenApi.previous, state, true) as
-      | RefObject
-      | undefined);
+  const previous = zodSchema._def.zodOpenApi?.previous
+    ? (createSchemaOrRef(zodSchema._def.zodOpenApi.previous, state, true) as
+        | RefObject
+        | undefined)
+    : undefined;
 
   const current =
     zodSchema._def.zodOpenApi?.current &&
@@ -236,14 +236,9 @@ export const createSchemaOrRef = <
 
   const ref = zodSchema._def.zodOpenApi?.openapi?.ref ?? component?.ref;
   if (ref) {
-    if (current) {
-      if (onlyRef) {
-        return current;
-      }
-      return createNewSchema({ zodSchema, previous: current, state });
-    }
-
-    return createNewRef({ ref, zodSchema, previous, state });
+    return current
+      ? createNewSchema({ zodSchema, previous: current, state })
+      : createNewRef({ ref, zodSchema, previous, state });
   }
 
   if (onlyRef) {

--- a/src/create/schema/index.ts
+++ b/src/create/schema/index.ts
@@ -59,10 +59,14 @@ export const createNewSchema = <
       ? zodSchema.description
       : undefined;
 
-  const schemaWithMetadata = enhanceWithMetadata(schema, {
-    ...(description && { description }),
-    ...additionalMetadata,
-  });
+  const schemaWithMetadata = enhanceWithMetadata(
+    schema,
+    {
+      ...(description && { description }),
+      ...additionalMetadata,
+    },
+    state,
+  );
   state.visited.delete(zodSchema);
   return schemaWithMetadata;
 };

--- a/src/create/schema/index.ts
+++ b/src/create/schema/index.ts
@@ -226,18 +226,17 @@ export const createSchemaOrRef = <
       | RefObject
       | undefined);
 
+  const current =
+    zodSchema._def.zodOpenApi?.current &&
+    zodSchema._def.zodOpenApi.current !== zodSchema
+      ? (createSchemaOrRef(zodSchema._def.zodOpenApi.current, state, true) as
+          | RefObject
+          | undefined)
+      : undefined;
+
   const ref = zodSchema._def.zodOpenApi?.openapi?.ref ?? component?.ref;
   if (ref) {
-    if (
-      zodSchema._def.zodOpenApi?.current &&
-      zodSchema._def.zodOpenApi?.current !== zodSchema
-    ) {
-      const current = createSchemaOrRef(
-        zodSchema._def.zodOpenApi.current,
-        state,
-        true,
-      ) as RefObject | undefined;
-
+    if (current) {
       if (onlyRef) {
         return current;
       }
@@ -248,10 +247,10 @@ export const createSchemaOrRef = <
   }
 
   if (onlyRef) {
-    return previous;
+    return previous ?? current;
   }
 
-  return createNewSchema({ zodSchema, previous, state });
+  return createNewSchema({ zodSchema, previous: previous ?? current, state });
 };
 
 export const createSchemaObject = <

--- a/src/create/schema/index.ts
+++ b/src/create/schema/index.ts
@@ -24,9 +24,6 @@ export interface SchemaState {
   documentOptions?: CreateSchemaOptions;
 }
 
-const isDescriptionEqual = (schema: Schema, zodSchema: ZodType): boolean =>
-  schema.type === 'ref' && zodSchema.description === schema.zodType.description;
-
 export const createNewSchema = <
   Output = unknown,
   Def extends ZodTypeDef = ZodTypeDef,
@@ -54,17 +51,10 @@ export const createNewSchema = <
   } = zodSchema._def.openapi ?? {};
 
   const schema = createSchemaSwitch(zodSchema, state);
-  const description =
-    zodSchema.description && !isDescriptionEqual(schema, zodSchema)
-      ? zodSchema.description
-      : undefined;
 
   const schemaWithMetadata = enhanceWithMetadata(
     schema,
-    {
-      ...(description && { description }),
-      ...additionalMetadata,
-    },
+    additionalMetadata,
     state,
   );
   state.visited.delete(zodSchema);

--- a/src/create/schema/metadata.test.ts
+++ b/src/create/schema/metadata.test.ts
@@ -206,6 +206,9 @@ describe('enhanceWithMetadata', () => {
   it('handles current and previous schemas', () => {
     const FooSchema = z.string().openapi({ ref: 'foo' });
     const CazSchema = z.object({ a: z.string() }).openapi({ ref: 'caz' });
+    const QuxSchema = CazSchema.extend({ b: FooSchema }).openapi({
+      ref: 'qux',
+    });
 
     const BarSchema = z.object({
       a: FooSchema.optional(),
@@ -221,6 +224,8 @@ describe('enhanceWithMetadata', () => {
       k: FooSchema.nullish().openapi({ description: 'bar' }),
       l: FooSchema.describe('bar'),
       m: CazSchema.openapi({ description: 'bar' }),
+      n: QuxSchema,
+      o: QuxSchema.extend({ c: FooSchema }).openapi({ description: 'qux' }),
     });
 
     const outputState = createOutputState();
@@ -477,6 +482,25 @@ describe('enhanceWithMetadata', () => {
         "$ref": "#/components/schemas/caz",
         "description": "bar",
       },
+      "n": {
+        "$ref": "#/components/schemas/qux",
+      },
+      "o": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/qux",
+          },
+        ],
+        "description": "qux",
+        "properties": {
+          "c": {
+            "$ref": "#/components/schemas/foo",
+          },
+        },
+        "required": [
+          "c",
+        ],
+      },
     },
     "required": [
       "c",
@@ -488,6 +512,8 @@ describe('enhanceWithMetadata', () => {
       "i",
       "l",
       "m",
+      "n",
+      "o",
     ],
     "type": "object",
   },
@@ -516,6 +542,23 @@ describe('enhanceWithMetadata', () => {
         "a",
       ],
       "type": "object",
+    },
+  },
+  {
+    "qux": {
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/caz",
+        },
+      ],
+      "properties": {
+        "b": {
+          "$ref": "#/components/schemas/foo",
+        },
+      },
+      "required": [
+        "b",
+      ],
     },
   },
 ]
@@ -770,6 +813,25 @@ describe('enhanceWithMetadata', () => {
         "$ref": "#/components/schemas/caz",
         "description": "bar",
       },
+      "n": {
+        "$ref": "#/components/schemas/qux",
+      },
+      "o": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/qux",
+          },
+        ],
+        "description": "qux",
+        "properties": {
+          "c": {
+            "$ref": "#/components/schemas/foo",
+          },
+        },
+        "required": [
+          "c",
+        ],
+      },
     },
     "required": [
       "c",
@@ -779,6 +841,8 @@ describe('enhanceWithMetadata', () => {
       "i",
       "l",
       "m",
+      "n",
+      "o",
     ],
     "type": "object",
   },
@@ -808,6 +872,23 @@ describe('enhanceWithMetadata', () => {
         "a",
       ],
       "type": "object",
+    },
+  },
+  {
+    "qux": {
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/caz",
+        },
+      ],
+      "properties": {
+        "b": {
+          "$ref": "#/components/schemas/foo",
+        },
+      },
+      "required": [
+        "b",
+      ],
     },
   },
 ]

--- a/src/create/schema/metadata.test.ts
+++ b/src/create/schema/metadata.test.ts
@@ -65,6 +65,10 @@ describe('enhanceWithMetadata', () => {
         $ref: '#/components/schemas/bla',
       },
       zodType: blaSchema,
+      schemaObject: {
+        type: 'string',
+        description: 'bla',
+      },
     };
 
     const result = createSchemaObject(fooSchema, createOutputState(), []);
@@ -96,6 +100,9 @@ describe('enhanceWithMetadata', () => {
         description: 'hello',
       },
       zodType: ref,
+      schemaObject: {
+        type: 'string',
+      },
     };
 
     const schema = ref.optional().openapi({ description: 'hello' });
@@ -135,6 +142,9 @@ describe('enhanceWithMetadata', () => {
         $ref: '#/components/schemas/og',
       },
       zodType: ref,
+      schemaObject: {
+        type: 'string',
+      },
     };
 
     const schema = ref.optional();
@@ -152,10 +162,8 @@ describe('enhanceWithMetadata', () => {
           {
             $ref: '#/components/schemas/ref2',
           },
-          {
-            default: 'a',
-          },
         ],
+        default: 'a',
       },
     };
 
@@ -175,7 +183,6 @@ describe('enhanceWithMetadata', () => {
         properties: {
           b: {
             allOf: [{ $ref: '#/components/schemas/a' }],
-            type: 'object',
             properties: { b: { type: 'string' } },
             required: ['b'],
             description: 'jello',

--- a/src/create/schema/metadata.test.ts
+++ b/src/create/schema/metadata.test.ts
@@ -1,7 +1,10 @@
 import '../../entries/extend';
 import { z } from 'zod';
 
-import { createOutputState } from '../../testing/state';
+import {
+  createOutputOpenapi3State,
+  createOutputState,
+} from '../../testing/state';
 
 import { type Schema, createSchemaObject } from './index';
 
@@ -83,7 +86,28 @@ describe('enhanceWithMetadata', () => {
     expect(result).toEqual(expected);
   });
 
-  it('adds allOf to $refs', () => {
+  it('adds adds a description alongside $ref when only description is added in 3.1.0', () => {
+    const ref = z.string().openapi({ ref: 'ref' });
+
+    const expected: Schema = {
+      type: 'ref',
+      schema: {
+        $ref: '#/components/schemas/ref',
+        description: 'hello',
+      },
+      zodType: ref,
+    };
+
+    const schema = ref.optional().openapi({ description: 'hello' });
+
+    const result = createSchemaObject(schema, createOutputState(), []);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('adds adds a description alongside allOf when only description is added in 3.0.0', () => {
+    const ref = z.string().openapi({ ref: 'ref' });
+
     const expected: Schema = {
       type: 'schema',
       schema: {
@@ -91,18 +115,14 @@ describe('enhanceWithMetadata', () => {
           {
             $ref: '#/components/schemas/ref',
           },
-          {
-            description: 'hello',
-          },
         ],
+        description: 'hello',
       },
     };
 
-    const ref = z.string().openapi({ ref: 'ref' });
-
     const schema = ref.optional().openapi({ description: 'hello' });
 
-    const result = createSchemaObject(schema, createOutputState(), []);
+    const result = createSchemaObject(schema, createOutputOpenapi3State(), []);
 
     expect(result).toEqual(expected);
   });

--- a/src/create/schema/metadata.test.ts
+++ b/src/create/schema/metadata.test.ts
@@ -2,6 +2,7 @@ import '../../entries/extend';
 import { z } from 'zod';
 
 import {
+  createInputState,
   createOutputOpenapi3State,
   createOutputState,
 } from '../../testing/state';
@@ -200,5 +201,505 @@ describe('enhanceWithMetadata', () => {
     const result = createSchemaObject(schema, createOutputState(), []);
 
     expect(result).toEqual(expected);
+  });
+
+  it('handles current and previous schemas', () => {
+    const FooSchema = z.string().openapi({ ref: 'foo' });
+
+    const BarSchema = z.object({
+      a: FooSchema.optional(),
+      b: FooSchema.openapi({ description: 'bar' }).optional(),
+      c: FooSchema.min(1).max(10),
+      d: FooSchema.openapi({ description: 'bar' }).min(1).max(10),
+      e: FooSchema.catch('a'),
+      f: FooSchema.default('a'),
+      g: FooSchema.email(),
+      h: FooSchema.datetime(),
+      i: FooSchema.openapi({ example: 'foo' }).min(1).max(10),
+    });
+
+    const result = createSchemaObject(BarSchema, createOutputState(), []);
+    const inputResult = createSchemaObject(BarSchema, createInputState(), []);
+    expect(result).toMatchInlineSnapshot(`
+{
+  "effects": [
+    {
+      "creationType": "output",
+      "path": [
+        "property: e",
+      ],
+      "type": "schema",
+      "zodType": ZodCatch {
+        "_def": {
+          "catchValue": [Function],
+          "description": undefined,
+          "errorMap": [Function],
+          "innerType": ZodString {
+            "_def": {
+              "checks": [],
+              "coerce": false,
+              "typeName": "ZodString",
+              "zodOpenApi": {
+                "current": [Circular],
+                "openapi": {
+                  "ref": "foo",
+                },
+              },
+            },
+            "and": [Function],
+            "array": [Function],
+            "brand": [Function],
+            "catch": [Function],
+            "default": [Function],
+            "describe": [Function],
+            "isNullable": [Function],
+            "isOptional": [Function],
+            "nullable": [Function],
+            "nullish": [Function],
+            "optional": [Function],
+            "or": [Function],
+            "parse": [Function],
+            "parseAsync": [Function],
+            "pipe": [Function],
+            "promise": [Function],
+            "readonly": [Function],
+            "refine": [Function],
+            "refinement": [Function],
+            "safeParse": [Function],
+            "safeParseAsync": [Function],
+            "spa": [Function],
+            "superRefine": [Function],
+            "transform": [Function],
+          },
+          "typeName": "ZodCatch",
+        },
+        "and": [Function],
+        "array": [Function],
+        "brand": [Function],
+        "catch": [Function],
+        "default": [Function],
+        "describe": [Function],
+        "isNullable": [Function],
+        "isOptional": [Function],
+        "nullable": [Function],
+        "nullish": [Function],
+        "optional": [Function],
+        "or": [Function],
+        "parse": [Function],
+        "parseAsync": [Function],
+        "pipe": [Function],
+        "promise": [Function],
+        "readonly": [Function],
+        "refine": [Function],
+        "refinement": [Function],
+        "safeParse": [Function],
+        "safeParseAsync": [Function],
+        "spa": [Function],
+        "superRefine": [Function],
+        "transform": [Function],
+      },
+    },
+    {
+      "creationType": "output",
+      "path": [
+        "property: f",
+      ],
+      "type": "schema",
+      "zodType": ZodDefault {
+        "_def": {
+          "defaultValue": [Function],
+          "description": undefined,
+          "errorMap": [Function],
+          "innerType": ZodString {
+            "_def": {
+              "checks": [],
+              "coerce": false,
+              "typeName": "ZodString",
+              "zodOpenApi": {
+                "current": [Circular],
+                "openapi": {
+                  "ref": "foo",
+                },
+              },
+            },
+            "and": [Function],
+            "array": [Function],
+            "brand": [Function],
+            "catch": [Function],
+            "default": [Function],
+            "describe": [Function],
+            "isNullable": [Function],
+            "isOptional": [Function],
+            "nullable": [Function],
+            "nullish": [Function],
+            "optional": [Function],
+            "or": [Function],
+            "parse": [Function],
+            "parseAsync": [Function],
+            "pipe": [Function],
+            "promise": [Function],
+            "readonly": [Function],
+            "refine": [Function],
+            "refinement": [Function],
+            "safeParse": [Function],
+            "safeParseAsync": [Function],
+            "spa": [Function],
+            "superRefine": [Function],
+            "transform": [Function],
+          },
+          "typeName": "ZodDefault",
+        },
+        "and": [Function],
+        "array": [Function],
+        "brand": [Function],
+        "catch": [Function],
+        "default": [Function],
+        "describe": [Function],
+        "isNullable": [Function],
+        "isOptional": [Function],
+        "nullable": [Function],
+        "nullish": [Function],
+        "optional": [Function],
+        "or": [Function],
+        "parse": [Function],
+        "parseAsync": [Function],
+        "pipe": [Function],
+        "promise": [Function],
+        "readonly": [Function],
+        "refine": [Function],
+        "refinement": [Function],
+        "safeParse": [Function],
+        "safeParseAsync": [Function],
+        "spa": [Function],
+        "superRefine": [Function],
+        "transform": [Function],
+      },
+    },
+  ],
+  "schema": {
+    "properties": {
+      "a": {
+        "$ref": "#/components/schemas/foo",
+      },
+      "b": {
+        "$ref": "#/components/schemas/foo",
+        "description": "bar",
+      },
+      "c": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/foo",
+          },
+        ],
+        "maxLength": 10,
+        "minLength": 1,
+      },
+      "d": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/foo",
+          },
+        ],
+        "description": "bar",
+        "maxLength": 10,
+        "minLength": 1,
+      },
+      "e": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/foo",
+          },
+        ],
+        "default": "a",
+      },
+      "f": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/foo",
+          },
+        ],
+        "default": "a",
+      },
+      "g": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/foo",
+          },
+        ],
+        "format": "email",
+      },
+      "h": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/foo",
+          },
+        ],
+        "format": "date-time",
+      },
+      "i": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/foo",
+          },
+        ],
+        "example": "foo",
+        "maxLength": 10,
+        "minLength": 1,
+      },
+    },
+    "required": [
+      "c",
+      "d",
+      "e",
+      "f",
+      "g",
+      "h",
+      "i",
+    ],
+    "type": "object",
+  },
+  "type": "schema",
+}
+`);
+
+    expect(inputResult).toMatchInlineSnapshot(`
+{
+  "effects": [
+    {
+      "creationType": "input",
+      "path": [
+        "property: e",
+      ],
+      "type": "schema",
+      "zodType": ZodCatch {
+        "_def": {
+          "catchValue": [Function],
+          "description": undefined,
+          "errorMap": [Function],
+          "innerType": ZodString {
+            "_def": {
+              "checks": [],
+              "coerce": false,
+              "typeName": "ZodString",
+              "zodOpenApi": {
+                "current": [Circular],
+                "openapi": {
+                  "ref": "foo",
+                },
+              },
+            },
+            "and": [Function],
+            "array": [Function],
+            "brand": [Function],
+            "catch": [Function],
+            "default": [Function],
+            "describe": [Function],
+            "isNullable": [Function],
+            "isOptional": [Function],
+            "nullable": [Function],
+            "nullish": [Function],
+            "optional": [Function],
+            "or": [Function],
+            "parse": [Function],
+            "parseAsync": [Function],
+            "pipe": [Function],
+            "promise": [Function],
+            "readonly": [Function],
+            "refine": [Function],
+            "refinement": [Function],
+            "safeParse": [Function],
+            "safeParseAsync": [Function],
+            "spa": [Function],
+            "superRefine": [Function],
+            "transform": [Function],
+          },
+          "typeName": "ZodCatch",
+        },
+        "and": [Function],
+        "array": [Function],
+        "brand": [Function],
+        "catch": [Function],
+        "default": [Function],
+        "describe": [Function],
+        "isNullable": [Function],
+        "isOptional": [Function],
+        "nullable": [Function],
+        "nullish": [Function],
+        "optional": [Function],
+        "or": [Function],
+        "parse": [Function],
+        "parseAsync": [Function],
+        "pipe": [Function],
+        "promise": [Function],
+        "readonly": [Function],
+        "refine": [Function],
+        "refinement": [Function],
+        "safeParse": [Function],
+        "safeParseAsync": [Function],
+        "spa": [Function],
+        "superRefine": [Function],
+        "transform": [Function],
+      },
+    },
+    {
+      "creationType": "input",
+      "path": [
+        "property: f",
+      ],
+      "type": "schema",
+      "zodType": ZodDefault {
+        "_def": {
+          "defaultValue": [Function],
+          "description": undefined,
+          "errorMap": [Function],
+          "innerType": ZodString {
+            "_def": {
+              "checks": [],
+              "coerce": false,
+              "typeName": "ZodString",
+              "zodOpenApi": {
+                "current": [Circular],
+                "openapi": {
+                  "ref": "foo",
+                },
+              },
+            },
+            "and": [Function],
+            "array": [Function],
+            "brand": [Function],
+            "catch": [Function],
+            "default": [Function],
+            "describe": [Function],
+            "isNullable": [Function],
+            "isOptional": [Function],
+            "nullable": [Function],
+            "nullish": [Function],
+            "optional": [Function],
+            "or": [Function],
+            "parse": [Function],
+            "parseAsync": [Function],
+            "pipe": [Function],
+            "promise": [Function],
+            "readonly": [Function],
+            "refine": [Function],
+            "refinement": [Function],
+            "safeParse": [Function],
+            "safeParseAsync": [Function],
+            "spa": [Function],
+            "superRefine": [Function],
+            "transform": [Function],
+          },
+          "typeName": "ZodDefault",
+        },
+        "and": [Function],
+        "array": [Function],
+        "brand": [Function],
+        "catch": [Function],
+        "default": [Function],
+        "describe": [Function],
+        "isNullable": [Function],
+        "isOptional": [Function],
+        "nullable": [Function],
+        "nullish": [Function],
+        "optional": [Function],
+        "or": [Function],
+        "parse": [Function],
+        "parseAsync": [Function],
+        "pipe": [Function],
+        "promise": [Function],
+        "readonly": [Function],
+        "refine": [Function],
+        "refinement": [Function],
+        "safeParse": [Function],
+        "safeParseAsync": [Function],
+        "spa": [Function],
+        "superRefine": [Function],
+        "transform": [Function],
+      },
+    },
+  ],
+  "schema": {
+    "properties": {
+      "a": {
+        "$ref": "#/components/schemas/foo",
+      },
+      "b": {
+        "$ref": "#/components/schemas/foo",
+        "description": "bar",
+      },
+      "c": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/foo",
+          },
+        ],
+        "maxLength": 10,
+        "minLength": 1,
+      },
+      "d": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/foo",
+          },
+        ],
+        "description": "bar",
+        "maxLength": 10,
+        "minLength": 1,
+      },
+      "e": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/foo",
+          },
+        ],
+        "default": "a",
+      },
+      "f": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/foo",
+          },
+        ],
+        "default": "a",
+      },
+      "g": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/foo",
+          },
+        ],
+        "format": "email",
+      },
+      "h": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/foo",
+          },
+        ],
+        "format": "date-time",
+      },
+      "i": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/foo",
+          },
+        ],
+        "example": "foo",
+        "maxLength": 10,
+        "minLength": 1,
+      },
+    },
+    "required": [
+      "c",
+      "d",
+      "g",
+      "h",
+      "i",
+    ],
+    "type": "object",
+  },
+  "type": "schema",
+}
+`);
   });
 });

--- a/src/create/schema/metadata.ts
+++ b/src/create/schema/metadata.ts
@@ -116,7 +116,6 @@ export const enhanceWithMetadata = (
       (acc, [key, value]) => {
         if (
           previous.schemaObject &&
-          !isReferenceObject(previous.schemaObject) &&
           isValueEqual(
             (previous.schemaObject as Record<string, unknown>)[key],
             value,

--- a/src/create/schema/metadata.ts
+++ b/src/create/schema/metadata.ts
@@ -3,7 +3,7 @@ import type { oas31 } from '../../openapi3-ts/dist';
 
 import type { RefObject, Schema, SchemaState } from '.';
 
-const createDescriptionMetadata = (
+export const createDescriptionMetadata = (
   schema: RefObject,
   description: string,
   state: SchemaState,
@@ -148,7 +148,6 @@ export const enhanceWithMetadata = (
       return createDescriptionMetadata(previous, diff.description, state);
     }
 
-    // Calculate if we can extend the previous schema
     return {
       type: 'schema',
       schema: { allOf: [previous.schema], ...diff },

--- a/src/create/schema/metadata.ts
+++ b/src/create/schema/metadata.ts
@@ -1,4 +1,4 @@
-import { isReferenceObject, satisfiesVersion } from '../../openapi';
+import { satisfiesVersion } from '../../openapi';
 import type { oas31 } from '../../openapi3-ts/dist';
 
 import type { RefObject, Schema, SchemaState } from '.';

--- a/src/create/schema/metadata.ts
+++ b/src/create/schema/metadata.ts
@@ -75,9 +75,10 @@ export const enhanceWithMetadata = (
     const diff = Object.entries({ ...schema.schema, ...values }).reduce(
       (acc, [key, value]) => {
         if (
-          previous.schemaObject &&
-          !isReferenceObject(previous.schemaObject) &&
-          (previous.schemaObject as Record<string, unknown>)[key] === value
+          ['oneOf', 'allOf', 'anyOf'].includes(key) ||
+          (previous.schemaObject &&
+            !isReferenceObject(previous.schemaObject) &&
+            (previous.schemaObject as Record<string, unknown>)[key] === value)
         ) {
           return acc;
         }

--- a/src/create/schema/metadata.ts
+++ b/src/create/schema/metadata.ts
@@ -1,14 +1,42 @@
+import { satisfiesVersion } from '../../openapi';
 import type { oas31 } from '../../openapi3-ts/dist';
 
-import type { Schema } from '.';
+import type { Schema, SchemaState } from '.';
 
 export const enhanceWithMetadata = (
   schema: Schema,
   metadata: oas31.SchemaObject | oas31.ReferenceObject,
+  state: SchemaState,
 ): Schema => {
   if (schema.type === 'ref') {
-    if (Object.values(metadata).every((val) => val === undefined)) {
+    const values = Object.values(metadata).filter((val) => val !== undefined);
+    const length = values.length;
+
+    if (length === 0) {
       return schema;
+    }
+
+    if (length === 1 && metadata.description) {
+      if (satisfiesVersion(state.components.openapi, '3.1.0')) {
+        return {
+          type: 'ref',
+          schema: {
+            description: metadata.description,
+            $ref: schema.schema.$ref,
+          },
+          zodType: schema.zodType,
+          effects: schema.effects,
+        };
+      }
+
+      return {
+        type: 'schema',
+        schema: {
+          description: metadata.description,
+          allOf: [schema.schema],
+        },
+        effects: schema.effects,
+      };
     }
 
     return {

--- a/src/create/schema/metadata.ts
+++ b/src/create/schema/metadata.ts
@@ -1,49 +1,115 @@
-import { satisfiesVersion } from '../../openapi';
+import { isReferenceObject, satisfiesVersion } from '../../openapi';
 import type { oas31 } from '../../openapi3-ts/dist';
 
-import type { Schema, SchemaState } from '.';
+import type { RefObject, Schema, SchemaState } from '.';
+
+const createDescriptionMetadata = (
+  schema: RefObject,
+  description: string,
+  state: SchemaState,
+): Schema => {
+  if (satisfiesVersion(state.components.openapi, '3.1.0')) {
+    return {
+      type: 'ref',
+      schema: {
+        $ref: schema.schema.$ref,
+        description,
+      },
+      zodType: schema.zodType,
+      effects: schema.effects,
+      schemaObject: schema.schemaObject,
+    };
+  }
+
+  return {
+    type: 'schema',
+    schema: {
+      description,
+      allOf: [schema.schema],
+    },
+    effects: schema.effects,
+  };
+};
 
 export const enhanceWithMetadata = (
   schema: Schema,
   metadata: oas31.SchemaObject | oas31.ReferenceObject,
   state: SchemaState,
+  previous: RefObject | undefined,
 ): Schema => {
-  if (schema.type === 'ref') {
-    const values = Object.values(metadata).filter((val) => val !== undefined);
-    const length = values.length;
+  const values = Object.entries(metadata).reduce(
+    (acc, [key, value]) => {
+      if (value === undefined) {
+        return acc;
+      }
 
+      acc[key] = value;
+      return acc;
+    },
+    {} as Record<string, unknown>,
+  ) as oas31.SchemaObject | oas31.ReferenceObject;
+
+  const length = Object.values(values).length;
+
+  if (schema.type === 'ref') {
     if (length === 0) {
       return schema;
     }
 
     if (length === 1 && metadata.description) {
-      if (satisfiesVersion(state.components.openapi, '3.1.0')) {
-        return {
-          type: 'ref',
-          schema: {
-            description: metadata.description,
-            $ref: schema.schema.$ref,
-          },
-          zodType: schema.zodType,
-          effects: schema.effects,
-        };
-      }
-
-      return {
-        type: 'schema',
-        schema: {
-          description: metadata.description,
-          allOf: [schema.schema],
-        },
-        effects: schema.effects,
-      };
+      return createDescriptionMetadata(schema, metadata.description, state);
     }
 
     return {
       type: 'schema',
       schema: {
-        allOf: [schema.schema, metadata],
+        allOf: [schema.schema],
+        ...metadata,
       },
+      effects: schema.effects,
+    };
+  }
+
+  // Calculate if we can extend the previous schema
+  if (previous && schema.schema.type !== 'object') {
+    const diff = Object.entries({ ...schema.schema, ...values }).reduce(
+      (acc, [key, value]) => {
+        if (
+          previous.schemaObject &&
+          !isReferenceObject(previous.schemaObject) &&
+          (previous.schemaObject as Record<string, unknown>)[key] === value
+        ) {
+          return acc;
+        }
+        acc[key] = value;
+
+        return acc;
+      },
+      {} as Record<string, unknown>,
+    );
+
+    const diffLength = Object.values(diff).length;
+
+    if (diffLength === 0) {
+      return {
+        type: 'ref',
+        schema: {
+          $ref: previous.schema.$ref,
+        },
+        effects: schema.effects,
+        schemaObject: previous.schemaObject,
+        zodType: previous.zodType,
+      };
+    }
+
+    if (diffLength === 1 && typeof diff.description === 'string') {
+      return createDescriptionMetadata(previous, diff.description, state);
+    }
+
+    // Calculate if we can extend the previous schema
+    return {
+      type: 'schema',
+      schema: { allOf: [previous.schema], ...diff },
       effects: schema.effects,
     };
   }

--- a/src/create/schema/parsers/catch.test.ts
+++ b/src/create/schema/parsers/catch.test.ts
@@ -17,7 +17,7 @@ describe('createCatchSchema', () => {
     };
     const schema = z.string().catch('bob');
 
-    const result = createCatchSchema(schema, createOutputState());
+    const result = createCatchSchema(schema, createOutputState(), undefined);
 
     expect(result).toEqual(expected);
   });

--- a/src/create/schema/parsers/catch.ts
+++ b/src/create/schema/parsers/catch.ts
@@ -1,6 +1,6 @@
 import type { ZodCatch, ZodTypeAny } from 'zod';
 
-import type { oas31 } from '../../../../dist';
+import type { oas31 } from '../../../openapi3-ts/dist';
 import {
   type Schema,
   type SchemaState,

--- a/src/create/schema/parsers/catch.ts
+++ b/src/create/schema/parsers/catch.ts
@@ -25,7 +25,11 @@ export const createCatchSchema = <T extends ZodTypeAny>(
         }
       : undefined;
 
-  return enhanceWithMetadata(schemaObject, {
-    ...maybeDefaultValue,
-  });
+  return enhanceWithMetadata(
+    schemaObject,
+    {
+      ...maybeDefaultValue,
+    },
+    state,
+  );
 };

--- a/src/create/schema/parsers/catch.ts
+++ b/src/create/schema/parsers/catch.ts
@@ -2,6 +2,7 @@ import type { ZodCatch, ZodTypeAny } from 'zod';
 
 import type { oas31 } from '../../../openapi3-ts/dist';
 import {
+  type RefObject,
   type Schema,
   type SchemaState,
   createSchemaObject,
@@ -11,6 +12,7 @@ import { enhanceWithMetadata } from '../metadata';
 export const createCatchSchema = <T extends ZodTypeAny>(
   zodCatch: ZodCatch<T>,
   state: SchemaState,
+  previous: RefObject | undefined,
 ): Schema => {
   const schemaObject = createSchemaObject(zodCatch._def.innerType, state, [
     'default',
@@ -31,5 +33,6 @@ export const createCatchSchema = <T extends ZodTypeAny>(
       ...maybeDefaultValue,
     },
     state,
+    previous,
   );
 };

--- a/src/create/schema/parsers/catch.ts
+++ b/src/create/schema/parsers/catch.ts
@@ -20,19 +20,12 @@ export const createCatchSchema = <T extends ZodTypeAny>(
 
   const catchResult = zodCatch.safeParse(undefined);
 
-  const maybeDefaultValue: Pick<oas31.SchemaObject, 'default'> | undefined =
+  const maybeDefaultValue: Pick<oas31.SchemaObject, 'default'> =
     catchResult.success
       ? {
           default: catchResult.data,
         }
-      : undefined;
+      : {};
 
-  return enhanceWithMetadata(
-    schemaObject,
-    {
-      ...maybeDefaultValue,
-    },
-    state,
-    previous,
-  );
+  return enhanceWithMetadata(schemaObject, maybeDefaultValue, state, previous);
 };

--- a/src/create/schema/parsers/default.test.ts
+++ b/src/create/schema/parsers/default.test.ts
@@ -30,10 +30,8 @@ describe('createDefaultSchema', () => {
           {
             $ref: '#/components/schemas/ref',
           },
-          {
-            default: 'a',
-          },
         ],
+        default: 'a',
       },
     };
     const schema = z.string().openapi({ ref: 'ref' }).optional().default('a');

--- a/src/create/schema/parsers/default.test.ts
+++ b/src/create/schema/parsers/default.test.ts
@@ -17,7 +17,7 @@ describe('createDefaultSchema', () => {
     };
     const schema = z.string().default('a');
 
-    const result = createDefaultSchema(schema, createOutputState());
+    const result = createDefaultSchema(schema, createOutputState(), undefined);
 
     expect(result).toEqual(expected);
   });
@@ -36,7 +36,7 @@ describe('createDefaultSchema', () => {
     };
     const schema = z.string().openapi({ ref: 'ref' }).optional().default('a');
 
-    const result = createDefaultSchema(schema, createOutputState());
+    const result = createDefaultSchema(schema, createOutputState(), undefined);
 
     expect(result).toEqual(expected);
   });

--- a/src/create/schema/parsers/default.ts
+++ b/src/create/schema/parsers/default.ts
@@ -15,7 +15,11 @@ export const createDefaultSchema = <T extends ZodTypeAny>(
     'default',
   ]);
 
-  return enhanceWithMetadata(schemaObject, {
-    default: zodDefault._def.defaultValue(),
-  });
+  return enhanceWithMetadata(
+    schemaObject,
+    {
+      default: zodDefault._def.defaultValue(),
+    },
+    state,
+  );
 };

--- a/src/create/schema/parsers/default.ts
+++ b/src/create/schema/parsers/default.ts
@@ -1,6 +1,7 @@
 import type { ZodDefault, ZodTypeAny } from 'zod';
 
 import {
+  type RefObject,
   type Schema,
   type SchemaState,
   createSchemaObject,
@@ -10,6 +11,7 @@ import { enhanceWithMetadata } from '../metadata';
 export const createDefaultSchema = <T extends ZodTypeAny>(
   zodDefault: ZodDefault<T>,
   state: SchemaState,
+  previous: RefObject | undefined,
 ): Schema => {
   const schemaObject = createSchemaObject(zodDefault._def.innerType, state, [
     'default',
@@ -21,5 +23,6 @@ export const createDefaultSchema = <T extends ZodTypeAny>(
       default: zodDefault._def.defaultValue(),
     },
     state,
+    previous,
   );
 };

--- a/src/create/schema/parsers/index.ts
+++ b/src/create/schema/parsers/index.ts
@@ -103,7 +103,7 @@ export const createSchemaSwitch = <
   }
 
   if (isZodType(zodSchema, 'ZodDefault')) {
-    return createDefaultSchema(zodSchema, state);
+    return createDefaultSchema(zodSchema, state, previous);
   }
 
   if (isZodType(zodSchema, 'ZodRecord')) {
@@ -152,7 +152,7 @@ export const createSchemaSwitch = <
   }
 
   if (isZodType(zodSchema, 'ZodCatch')) {
-    return createCatchSchema(zodSchema, state);
+    return createCatchSchema(zodSchema, state, previous);
   }
 
   if (isZodType(zodSchema, 'ZodUnknown') || isZodType(zodSchema, 'ZodAny')) {

--- a/src/create/schema/parsers/index.ts
+++ b/src/create/schema/parsers/index.ts
@@ -1,7 +1,7 @@
 import type { ZodType, ZodTypeDef } from 'zod';
 
 import { isZodType } from '../../../zodType';
-import type { Schema, SchemaState } from '../../schema';
+import type { RefObject, Schema, SchemaState } from '../../schema';
 
 import { createArraySchema } from './array';
 import { createBooleanSchema } from './boolean';
@@ -39,6 +39,7 @@ export const createSchemaSwitch = <
   Input = Output,
 >(
   zodSchema: ZodType<Output, Def, Input>,
+  previous: RefObject | undefined,
   state: SchemaState,
 ): Schema => {
   if (zodSchema._def.zodOpenApi?.openapi?.type) {
@@ -74,7 +75,7 @@ export const createSchemaSwitch = <
   }
 
   if (isZodType(zodSchema, 'ZodObject')) {
-    return createObjectSchema(zodSchema, state);
+    return createObjectSchema(zodSchema, previous, state);
   }
 
   if (isZodType(zodSchema, 'ZodUnion')) {

--- a/src/create/schema/parsers/index.ts
+++ b/src/create/schema/parsers/index.ts
@@ -41,7 +41,7 @@ export const createSchemaSwitch = <
   zodSchema: ZodType<Output, Def, Input>,
   state: SchemaState,
 ): Schema => {
-  if (zodSchema._def.openapi?.type) {
+  if (zodSchema._def.zodOpenApi?.openapi?.type) {
     return createManualTypeSchema(zodSchema, state);
   }
 

--- a/src/create/schema/parsers/lazy.test.ts
+++ b/src/create/schema/parsers/lazy.test.ts
@@ -132,6 +132,7 @@ describe('createLazySchema', () => {
 
     const result = createObjectSchema(
       UserSchema as ZodObject<any, any, any, any, any>,
+      undefined,
       state,
     );
 
@@ -210,7 +211,11 @@ describe('createLazySchema', () => {
       ref: 'post',
     });
 
-    const result = createNewSchema(UserSchema, state);
+    const result = createNewSchema({
+      zodSchema: UserSchema,
+      previous: undefined,
+      state,
+    });
 
     expect(result.schema).toEqual(expected);
   });
@@ -258,7 +263,7 @@ describe('createLazySchema', () => {
 
     const state = createOutputState();
 
-    const result = createObjectSchema(ContainerSchema, state);
+    const result = createObjectSchema(ContainerSchema, undefined, state);
 
     expect(result).toEqual(expected);
 

--- a/src/create/schema/parsers/manual.ts
+++ b/src/create/schema/parsers/manual.ts
@@ -10,7 +10,7 @@ export const createManualTypeSchema = <
   zodSchema: ZodType<Output, Def, Input>,
   state: SchemaState,
 ): Schema => {
-  if (!zodSchema._def.openapi?.type) {
+  if (!zodSchema._def.zodOpenApi?.openapi?.type) {
     const schemaName = zodSchema.constructor.name;
     throw new Error(
       `Unknown schema ${schemaName} at ${state.path.join(
@@ -22,7 +22,7 @@ export const createManualTypeSchema = <
   return {
     type: 'schema',
     schema: {
-      type: zodSchema._def.openapi.type,
+      type: zodSchema._def.zodOpenApi?.openapi.type,
     },
   };
 };

--- a/src/create/schema/parsers/nullable.test.ts
+++ b/src/create/schema/parsers/nullable.test.ts
@@ -88,7 +88,6 @@ describe('createNullableSchema', () => {
         properties: {
           b: {
             allOf: [{ $ref: '#/components/schemas/a' }],
-            type: 'object',
             properties: { b: { type: 'string' } },
             required: ['b'],
             nullable: true,
@@ -215,7 +214,6 @@ describe('createNullableSchema', () => {
               oneOf: [
                 {
                   allOf: [{ $ref: '#/components/schemas/a' }],
-                  type: 'object',
                   properties: { b: { type: 'string' } },
                   required: ['b'],
                 },

--- a/src/create/schema/parsers/object.test.ts
+++ b/src/create/schema/parsers/object.test.ts
@@ -24,7 +24,7 @@ describe('createObjectSchema', () => {
       b: z.string().optional(),
     });
 
-    const result = createObjectSchema(schema, createOutputState());
+    const result = createObjectSchema(schema, undefined, createOutputState());
 
     expect(result).toEqual(expected);
   });
@@ -47,7 +47,7 @@ describe('createObjectSchema', () => {
       a: z.string(),
     });
 
-    const result = createObjectSchema(schema, createOutputState());
+    const result = createObjectSchema(schema, undefined, createOutputState());
 
     expect(result).toEqual(expected);
   });
@@ -70,7 +70,9 @@ describe('createObjectSchema', () => {
       })
       .catchall(z.boolean());
 
-    expect(createObjectSchema(schema, createOutputState())).toEqual(expected);
+    expect(createObjectSchema(schema, undefined, createOutputState())).toEqual(
+      expected,
+    );
   });
 
   it('considers ZodDefault in an input state as an effect', () => {
@@ -96,7 +98,7 @@ describe('createObjectSchema', () => {
       ],
     };
 
-    const result = createObjectSchema(schema, createInputState());
+    const result = createObjectSchema(schema, undefined, createInputState());
 
     expect(result).toEqual(expected);
   });
@@ -124,7 +126,7 @@ describe('createObjectSchema', () => {
       ],
     };
 
-    const result = createObjectSchema(schema, createInputState());
+    const result = createObjectSchema(schema, undefined, createInputState());
 
     expect(result).toEqual(expected);
   });
@@ -153,7 +155,7 @@ describe('createObjectSchema', () => {
       ],
     };
 
-    const result = createObjectSchema(schema, createOutputState());
+    const result = createObjectSchema(schema, undefined, createOutputState());
 
     expect(result).toEqual(expected);
   });
@@ -182,7 +184,7 @@ describe('createObjectSchema', () => {
       ],
     };
 
-    const result = createObjectSchema(schema, createOutputState());
+    const result = createObjectSchema(schema, undefined, createOutputState());
 
     expect(result).toEqual(expected);
   });
@@ -202,7 +204,7 @@ describe('required', () => {
         h: z.string().catch('a'),
       });
 
-      const result = createObjectSchema(schema, createOutputState());
+      const result = createObjectSchema(schema, undefined, createOutputState());
 
       expect(result).toEqual<Schema>({
         effects: expect.any(Array),
@@ -246,7 +248,7 @@ describe('required', () => {
           .pipe(z.number().optional()),
       });
 
-      const result = createObjectSchema(schema, createOutputState());
+      const result = createObjectSchema(schema, undefined, createOutputState());
 
       expect(result).toEqual<Schema>({
         effects: expect.any(Array),
@@ -280,7 +282,7 @@ describe('required', () => {
         f: z.custom((r) => r !== undefined),
       });
 
-      const result = createObjectSchema(schema, createInputState());
+      const result = createObjectSchema(schema, undefined, createInputState());
 
       expect(result).toEqual<Schema>({
         type: 'schema',
@@ -322,7 +324,7 @@ describe('required', () => {
         m: z.string().default('a'),
       });
 
-      const result = createObjectSchema(schema, createInputState());
+      const result = createObjectSchema(schema, undefined, createInputState());
 
       expect(result).toEqual<Schema>({
         effects: expect.any(Array),
@@ -357,7 +359,6 @@ describe('extend', () => {
           obj1: { $ref: '#/components/schemas/obj1' },
           obj2: {
             allOf: [{ $ref: '#/components/schemas/obj1' }],
-            type: 'object',
             properties: { b: { type: 'string' } },
             required: ['b'],
           },
@@ -372,7 +373,7 @@ describe('extend', () => {
       obj2: object2,
     });
 
-    const result = createObjectSchema(schema, createOutputState());
+    const result = createObjectSchema(schema, undefined, createOutputState());
 
     expect(result).toEqual(expected);
   });
@@ -406,7 +407,7 @@ describe('extend', () => {
       obj2: object2,
     });
 
-    const result = createObjectSchema(schema, createOutputState());
+    const result = createObjectSchema(schema, undefined, createOutputState());
 
     expect(result).toEqual(expected);
   });
@@ -420,7 +421,6 @@ describe('extend', () => {
           obj1: { $ref: '#/components/schemas/obj1' },
           obj2: {
             allOf: [{ $ref: '#/components/schemas/obj1' }],
-            type: 'object',
             properties: { b: { type: 'number' } },
             required: ['b'],
             additionalProperties: {
@@ -438,7 +438,7 @@ describe('extend', () => {
       obj2: object2,
     });
 
-    const result = createObjectSchema(schema, createOutputState());
+    const result = createObjectSchema(schema, undefined, createOutputState());
 
     expect(result).toEqual(expected);
   });
@@ -452,7 +452,7 @@ describe('extend', () => {
     });
 
     const state = createOutputState();
-    createObjectSchema(schema, state);
+    createObjectSchema(schema, undefined, state);
 
     expect(state.components.schemas.get(object1)?.ref).toBe('obj1');
     expect(state.components.schemas.get(object1)?.type).toBe('complete');
@@ -481,7 +481,7 @@ describe('extend', () => {
       obj2: object2,
     });
 
-    const result = createObjectSchema(schema, createOutputState());
+    const result = createObjectSchema(schema, undefined, createOutputState());
 
     expect(result).toEqual(expected);
   });
@@ -518,7 +518,7 @@ describe('extend', () => {
       b: zodDate,
     });
 
-    const result = createObjectSchema(schema, createOutputState());
+    const result = createObjectSchema(schema, undefined, createOutputState());
 
     expect(result).toEqual(expected);
   });

--- a/src/create/schema/parsers/object.ts
+++ b/src/create/schema/parsers/object.ts
@@ -32,7 +32,7 @@ export const createObjectSchema = <
 ): Schema => {
   const extendedSchema = createExtendedSchema(
     zodObject,
-    zodObject._def.previous as
+    zodObject._def.zodOpenApi?.previous as
       | ZodObject<T, UnknownKeys, Catchall, Output, Input>
       | undefined,
     state,
@@ -68,7 +68,7 @@ export const createExtendedSchema = <
   }
 
   const component = state.components.schemas.get(baseZodObject);
-  if (component ?? baseZodObject._def.openapi?.ref) {
+  if (component ?? baseZodObject._def.zodOpenApi?.openapi.ref) {
     createSchemaObject(baseZodObject, state, ['extended schema']);
   }
 

--- a/src/create/schema/parsers/object.ts
+++ b/src/create/schema/parsers/object.ts
@@ -32,7 +32,9 @@ export const createObjectSchema = <
 ): Schema => {
   const extendedSchema = createExtendedSchema(
     zodObject,
-    zodObject._def.extendMetadata?.extends,
+    zodObject._def.previous as
+      | ZodObject<T, UnknownKeys, Catchall, Output, Input>
+      | undefined,
     state,
   );
 

--- a/src/create/schema/parsers/pipeline.ts
+++ b/src/create/schema/parsers/pipeline.ts
@@ -16,13 +16,13 @@ export const createPipelineSchema = <
   state: SchemaState,
 ): Schema => {
   if (
-    zodPipeline._def.openapi?.effectType === 'input' ||
-    zodPipeline._def.openapi?.effectType === 'same'
+    zodPipeline._def.zodOpenApi?.openapi?.effectType === 'input' ||
+    zodPipeline._def.zodOpenApi?.openapi?.effectType === 'same'
   ) {
     return createSchemaObject(zodPipeline._def.in, state, ['pipeline input']);
   }
 
-  if (zodPipeline._def.openapi?.effectType === 'output') {
+  if (zodPipeline._def.zodOpenApi?.openapi?.effectType === 'output') {
     return createSchemaObject(zodPipeline._def.out, state, ['pipeline output']);
   }
 

--- a/src/create/schema/parsers/transform.ts
+++ b/src/create/schema/parsers/transform.ts
@@ -24,7 +24,7 @@ export const createTransformSchema = <
   zodTransform: ZodEffects<T, Output, Input>,
   state: SchemaState,
 ): Schema => {
-  if (zodTransform._def.openapi?.effectType === 'output') {
+  if (zodTransform._def.zodOpenApi?.openapi?.effectType === 'output') {
     return {
       type: 'schema',
       schema: createManualOutputTransformSchema(zodTransform, state),
@@ -32,8 +32,8 @@ export const createTransformSchema = <
   }
 
   if (
-    zodTransform._def.openapi?.effectType === 'input' ||
-    zodTransform._def.openapi?.effectType === 'same'
+    zodTransform._def.zodOpenApi?.openapi?.effectType === 'input' ||
+    zodTransform._def.zodOpenApi?.openapi?.effectType === 'same'
   ) {
     return createSchemaObject(zodTransform._def.schema, state, [
       'transform input',
@@ -75,7 +75,7 @@ export const createManualOutputTransformSchema = <
   zodTransform: ZodEffects<T, Output, Input>,
   state: SchemaState,
 ): oas31.SchemaObject => {
-  if (!zodTransform._def.openapi?.type) {
+  if (!zodTransform._def.zodOpenApi?.openapi?.type) {
     const zodType = zodTransform.constructor.name;
     const schemaName = `${zodType} - ${zodTransform._def.effect.type}`;
     throw new Error(
@@ -86,7 +86,7 @@ export const createManualOutputTransformSchema = <
   }
 
   return {
-    type: zodTransform._def.openapi.type,
+    type: zodTransform._def.zodOpenApi?.openapi.type,
   };
 };
 

--- a/src/create/schema/parsers/union.ts
+++ b/src/create/schema/parsers/union.ts
@@ -22,7 +22,10 @@ export const createUnionSchema = <
     return acc;
   }, []);
 
-  if (zodUnion._def.openapi?.unionOneOf ?? state.documentOptions?.unionOneOf) {
+  if (
+    zodUnion._def.zodOpenApi?.openapi?.unionOneOf ??
+    state.documentOptions?.unionOneOf
+  ) {
     return {
       type: 'schema',
       schema: {

--- a/src/create/schema/single.test.ts
+++ b/src/create/schema/single.test.ts
@@ -1,4 +1,4 @@
-import 'zod-openapi/extend';
+import '../../entries/extend';
 import { z } from 'zod';
 
 import { type SchemaResult, createSchema } from './single';

--- a/src/extendZod.test.ts
+++ b/src/extendZod.test.ts
@@ -87,6 +87,6 @@ describe('extendZodWithOpenApi', () => {
 
     const barString = fooString.openapi({ description: 'foo' });
 
-    expect(barString._def.zodOpenApi?.openapi.effectType).toBe('input');
+    expect(barString._def.zodOpenApi?.openapi?.effectType).toBe('input');
   });
 });

--- a/src/extendZod.test.ts
+++ b/src/extendZod.test.ts
@@ -14,6 +14,15 @@ describe('extendZodWithOpenApi', () => {
     expect(() => run()).not.toThrow();
   });
 
+  it('allows .openapi() to be chained in Zod Types', () => {
+    const a = z.string().openapi({ description: 'test' });
+    const b = a.openapi({ description: 'test2' });
+
+    expect(a._def.openapi?.description).toBe('test');
+    expect(b._def.openapi?.description).toBe('test2');
+    expect(b._def.previous?._def.openapi?.description).toBe('test');
+  });
+
   it('adds ._def.openapi fields to a zod type', () => {
     const a = z.string().openapi({ description: 'a' });
     const b = z.number().openapi({ examples: [1] });
@@ -33,7 +42,7 @@ describe('extendZodWithOpenApi', () => {
     const b = a.extend({ b: z.string() });
 
     expect(a._def.openapi?.ref).toBe('a');
-    expect(b._def.extendMetadata?.extends).toStrictEqual(a);
+    expect(b._def?.previous).toStrictEqual(a);
   });
 
   it('adds removes extendsMetadata to an object when .omit or .pick is used', () => {
@@ -43,10 +52,8 @@ describe('extendZodWithOpenApi', () => {
     const d = b.omit({ a: true });
 
     expect(a._def.openapi?.ref).toBe('a');
-    expect(b._def.extendMetadata?.extends).toStrictEqual(a);
-    expect(c._def.extendMetadata).toBeUndefined();
+    expect(b._def.previous).toStrictEqual(a);
     expect(c._def.openapi).toBeUndefined();
-    expect(d._def.extendMetadata).toBeUndefined();
     expect(d._def.openapi).toBeUndefined();
   });
 

--- a/src/extendZod.test.ts
+++ b/src/extendZod.test.ts
@@ -18,43 +18,53 @@ describe('extendZodWithOpenApi', () => {
     const a = z.string().openapi({ description: 'test' });
     const b = a.openapi({ description: 'test2' });
 
-    expect(a._def.openapi?.description).toBe('test');
-    expect(b._def.openapi?.description).toBe('test2');
-    expect(b._def.previous?._def.openapi?.description).toBe('test');
+    expect(a._def.zodOpenApi?.openapi?.description).toBe('test');
+    expect(b._def.zodOpenApi?.openapi?.description).toBe('test2');
+    expect(
+      b._def.zodOpenApi?.previous?._def.zodOpenApi?.openapi?.description,
+    ).toBe('test');
   });
 
-  it('adds ._def.openapi fields to a zod type', () => {
+  it('sets current metadata when a schema is used again', () => {
+    const a = z.string().openapi({ ref: 'a' });
+    const b = a.uuid();
+
+    expect(a._def.zodOpenApi?.current).toBe(a);
+    expect(b._def.zodOpenApi?.current).toBe(a);
+  });
+
+  it('adds ._def.zodOpenApi.openapi fields to a zod type', () => {
     const a = z.string().openapi({ description: 'a' });
     const b = z.number().openapi({ examples: [1] });
 
-    expect(a._def.openapi?.description).toBe('a');
-    expect(b._def.openapi?.examples).toStrictEqual([1]);
+    expect(a._def.zodOpenApi?.openapi?.description).toBe('a');
+    expect(b._def.zodOpenApi?.openapi?.examples).toStrictEqual([1]);
   });
 
   it('adds persists .openapi() across some methods', () => {
     const a = z.string().openapi({ description: 'a' }).uuid();
 
-    expect(a._def.openapi?.description).toBe('a');
+    expect(a._def.zodOpenApi?.openapi?.description).toBe('a');
   });
 
   it('adds extendsMetadata to an object when .extend is used', () => {
     const a = z.object({ a: z.string() }).openapi({ ref: 'a' });
     const b = a.extend({ b: z.string() });
 
-    expect(a._def.openapi?.ref).toBe('a');
-    expect(b._def?.previous).toStrictEqual(a);
+    expect(a._def.zodOpenApi?.openapi?.ref).toBe('a');
+    expect(b._def.zodOpenApi?.previous).toStrictEqual(a);
   });
 
-  it('adds removes extendsMetadata to an object when .omit or .pick is used', () => {
+  it('removes previous openapi ref for an object when .omit or .pick is used', () => {
     const a = z.object({ a: z.string() }).openapi({ ref: 'a' });
     const b = a.extend({ b: z.string() });
     const c = b.pick({ a: true });
     const d = b.omit({ a: true });
 
-    expect(a._def.openapi?.ref).toBe('a');
-    expect(b._def.previous).toStrictEqual(a);
-    expect(c._def.openapi).toBeUndefined();
-    expect(d._def.openapi).toBeUndefined();
+    expect(a._def.zodOpenApi?.openapi?.ref).toBe('a');
+    expect(b._def.zodOpenApi?.previous).toStrictEqual(a);
+    expect(c._def.zodOpenApi?.openapi).toEqual({});
+    expect(d._def.zodOpenApi?.openapi).toEqual({});
   });
 
   it("allows 'same' effectType when the input and output are equal", () => {
@@ -66,5 +76,17 @@ describe('extendZodWithOpenApi', () => {
       .transform((string) => string.length)
       // @ts-expect-error - This is to test the effectType
       .openapi({ effectType: 'same' });
+  });
+
+  it('preserves properties when using .openapi consecutively', () => {
+    const fooString = z
+      .string()
+      .regex(/^foo/)
+      .transform((string) => string.toUpperCase())
+      .openapi({ effectType: 'input' });
+
+    const barString = fooString.openapi({ description: 'foo' });
+
+    expect(barString._def.zodOpenApi?.openapi.effectType).toBe('input');
   });
 });

--- a/src/extendZod.ts
+++ b/src/extendZod.ts
@@ -1,25 +1,53 @@
 import type { ZodRawShape, ZodTypeDef, z } from 'zod';
+
 import './extendZodTypes';
+
+type ZodOpenApiMetadataDef = NonNullable<ZodTypeDef['zodOpenApi']>;
+type ZodOpenApiMetadata = ZodOpenApiMetadataDef['openapi'];
+
+const mergeOpenApi = (
+  openapi: ZodOpenApiMetadata,
+  {
+    ref: _ref,
+    refType: _refType,
+    param: _param,
+    header: _header,
+    ...rest
+  }: ZodOpenApiMetadata = {},
+) => ({
+  ...rest,
+  ...openapi,
+});
 
 export function extendZodWithOpenApi(zod: typeof z) {
   if (typeof zod.ZodType.prototype.openapi !== 'undefined') {
     return;
   }
-  zod.ZodType.prototype.openapi = function (openapi) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const { openapi: prevOpenapi, ...rest } = this._def;
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const previous: Pick<ZodTypeDef, 'previous'> = prevOpenapi && {
-      previous: this,
+  zod.ZodType.prototype.openapi = function (openapi) {
+    const { zodOpenApi, ...rest } = this._def as {
+      zodOpenApi?: ZodOpenApiMetadataDef;
+      [key: string]: unknown;
     };
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
     const result = new (this as any).constructor({
       ...rest,
-      ...previous,
-      openapi,
+      zodOpenApi: {
+        openapi: mergeOpenApi(
+          openapi as unknown as ZodOpenApiMetadata,
+          zodOpenApi?.openapi,
+        ),
+      },
     });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    result._def.zodOpenApi.current = result;
+
+    if (zodOpenApi) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      result._def.zodOpenApi.previous = this;
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return result;
@@ -28,9 +56,9 @@ export function extendZodWithOpenApi(zod: typeof z) {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const zodDescribe = zod.ZodObject.prototype.describe;
 
-  zod.ZodType.prototype.describe = function (description) {
-    const result = zodDescribe.apply(this, [description]);
-    return result.openapi({ description });
+  zod.ZodType.prototype.describe = function (...args: [description: string]) {
+    const result = zodDescribe.apply(this, args);
+    return result.openapi({ description: args[0] });
   };
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -41,9 +69,12 @@ export function extendZodWithOpenApi(zod: typeof z) {
   ) {
     const extendResult = zodObjectExtend.apply(this, args);
 
-    if (extendResult._def.openapi) {
-      delete extendResult._def.openapi;
-      extendResult._def.previous = this;
+    const zodOpenApi = extendResult._def.zodOpenApi;
+    if (zodOpenApi) {
+      const cloned = { ...zodOpenApi };
+      cloned.openapi = mergeOpenApi({}, cloned.openapi);
+      cloned.previous = this;
+      extendResult._def.zodOpenApi = cloned;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
@@ -58,9 +89,12 @@ export function extendZodWithOpenApi(zod: typeof z) {
   ) {
     const omitResult = zodObjectOmit.apply(this, args);
 
-    if (omitResult._def.openapi) {
-      delete omitResult._def.openapi;
-      omitResult._def.previous = this;
+    const zodOpenApi = omitResult._def.zodOpenApi;
+    if (zodOpenApi) {
+      const cloned = { ...zodOpenApi };
+      cloned.openapi = mergeOpenApi({}, cloned.openapi);
+      delete cloned.previous;
+      omitResult._def.zodOpenApi = cloned;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
@@ -75,9 +109,12 @@ export function extendZodWithOpenApi(zod: typeof z) {
   ) {
     const pickResult = zodObjectPick.apply(this, args);
 
-    if (pickResult._def.openapi) {
-      delete pickResult._def.openapi;
-      pickResult._def.previous = this;
+    const zodOpenApi = pickResult._def.zodOpenApi;
+    if (zodOpenApi) {
+      const cloned = { ...zodOpenApi };
+      cloned.openapi = mergeOpenApi({}, cloned.openapi);
+      delete cloned.previous;
+      pickResult._def.zodOpenApi = cloned;
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
     return pickResult as any;

--- a/src/extendZod.ts
+++ b/src/extendZod.ts
@@ -75,6 +75,10 @@ export function extendZodWithOpenApi(zod: typeof z) {
       cloned.openapi = mergeOpenApi({}, cloned.openapi);
       cloned.previous = this;
       extendResult._def.zodOpenApi = cloned;
+    } else {
+      extendResult._def.zodOpenApi = {
+        previous: this,
+      };
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any

--- a/src/extendZod.ts
+++ b/src/extendZod.ts
@@ -26,6 +26,14 @@ export function extendZodWithOpenApi(zod: typeof z) {
   };
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
+  const zodDescribe = zod.ZodObject.prototype.describe;
+
+  zod.ZodType.prototype.describe = function (description) {
+    const result = zodDescribe.apply(this, [description]);
+    return result.openapi({ description });
+  };
+
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const zodObjectExtend = zod.ZodObject.prototype.extend;
 
   zod.ZodObject.prototype.extend = function (

--- a/src/extendZodTypes.ts
+++ b/src/extendZodTypes.ts
@@ -66,6 +66,21 @@ interface ZodOpenApiMetadata<
   type?: SchemaObject['type'];
 }
 
+interface ZodOpenApiMetadataDef {
+  /**
+   * Up to date OpenAPI metadata
+   */
+  openapi: ZodOpenApiMetadata<ZodTypeAny>;
+  /**
+   * Used to keep track of the Zod Schema had `.openapi` called on it
+   */
+  current?: ZodTypeAny;
+  /**
+   * Used to keep track of the previous Zod Schema that had `.openapi` called on it if another `.openapi` is called
+   */
+  previous?: ZodTypeAny;
+}
+
 interface ZodOpenApiExtendMetadata {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   extends: ZodObject<any, any, any, any, any>;
@@ -80,11 +95,7 @@ declare module 'zod' {
   }
 
   interface ZodTypeDef {
-    /**
-     * OpenAPI metadata
-     */
-    openapi?: ZodOpenApiMetadata<ZodTypeAny>;
-    previous?: ZodTypeAny;
+    zodOpenApi?: ZodOpenApiMetadataDef;
   }
 
   export interface ZodObjectDef {

--- a/src/extendZodTypes.ts
+++ b/src/extendZodTypes.ts
@@ -84,6 +84,7 @@ declare module 'zod' {
      * OpenAPI metadata
      */
     openapi?: ZodOpenApiMetadata<ZodTypeAny>;
+    previous?: ZodTypeAny;
   }
 
   export interface ZodObjectDef {

--- a/src/extendZodTypes.ts
+++ b/src/extendZodTypes.ts
@@ -70,13 +70,14 @@ interface ZodOpenApiMetadataDef {
   /**
    * Up to date OpenAPI metadata
    */
-  openapi: ZodOpenApiMetadata<ZodTypeAny>;
+  openapi?: ZodOpenApiMetadata<ZodTypeAny>;
   /**
    * Used to keep track of the Zod Schema had `.openapi` called on it
    */
   current?: ZodTypeAny;
   /**
-   * Used to keep track of the previous Zod Schema that had `.openapi` called on it if another `.openapi` is called
+   * Used to keep track of the previous Zod Schema that had `.openapi` called on it if another `.openapi` is called.
+   * This can also be present when .extend is called on an object.
    */
   previous?: ZodTypeAny;
 }

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -21,5 +21,5 @@ export const isReferenceObject = (
     | oas31.ReferenceObject
     | oas30.SchemaObject
     | oas30.ReferenceObject,
-): schemaOrRef is oas31.ReferenceObject =>
+): schemaOrRef is oas31.ReferenceObject | oas30.ReferenceObject =>
   Boolean('$ref' in schemaOrRef && schemaOrRef.$ref);

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,4 +1,4 @@
-import type { oas31 } from './openapi3-ts/dist';
+import type { oas30, oas31 } from './openapi3-ts/dist';
 
 export const openApiVersions = [
   '3.0.0',
@@ -16,6 +16,10 @@ export const satisfiesVersion = (
 ) => openApiVersions.indexOf(test) >= openApiVersions.indexOf(against);
 
 export const isReferenceObject = (
-  schemaOrRef: oas31.SchemaObject | oas31.ReferenceObject,
+  schemaOrRef:
+    | oas31.SchemaObject
+    | oas31.ReferenceObject
+    | oas30.SchemaObject
+    | oas30.ReferenceObject,
 ): schemaOrRef is oas31.ReferenceObject =>
   Boolean('$ref' in schemaOrRef && schemaOrRef.$ref);


### PR DESCRIPTION
Resolves https://github.com/samchungy/zod-openapi/issues/303

`.openapi()` behaves a little differently now.

It now will attempt to store any `previous` openapi state and use it.

## Why do we need this change?

1. Unintuitive Extension
	```ts
	const FooSchema = z.string().openapi({ ref: 'string' });
	
	const BarSchema = z.object({
	  a: FooSchema,
	  b: FooSchema.openapi({ description: 'foo' }),
	});
	
	createSchema(BarSchema)
	```
	
	This currently generates the following:
	
	```ts
	{
	  schema: {
	    type: 'object',
	    properties: {
	      a: { '$ref': '#/components/schemas/string' },
	      b: { type: 'string', description: 'foo' }
	    },
	    required: [ 'a', 'b' ]
	  },
	  components: { string: { type: 'string' } }
	}
	```

	However, it's clear that the user simply wanted to reuse the FooSchema but describe it as something else later on.
	
	After:
	```ts
	{
	  schema: {
	    type: 'object',
	    properties: {
	      a: { '$ref': '#/components/schemas/string' },
	      b: { '$ref': '#/components/schemas/string', description: 'foo' }
	    },
	    required: [ 'a', 'b' ]
	  },
	  components: { string: { type: 'string' } }
	}
	```

2. Broken `.describe()` behaviour on registered schemas

	```ts
		const FooSchema = z.string().openapi({ ref: 'string' });
		
		const BarSchema = z.object({
		  a: FooSchema,
		  b: FooSchema.describe('foo')
		});
		
		createSchema(BarSchema)
	```
	
	This scenario actually causes us to crash because it attempts to register the FooSchema twice with different objects because the `.describe()` triggers `Schema "string" is already registered`
	
	After:
	```ts
	{
	  schema: {
	    type: 'object',
	    properties: {
	      a: { '$ref': '#/components/schemas/string' },
	      b: { '$ref': '#/components/schemas/string', description: 'foo' }
	    },
	    required: [ 'a', 'b' ]
	  },
	  components: { string: { type: 'string' } }
	}
	```

3. Unregistered Base Schemas. You would think that if you created a base schema, and used it in a schema with something like a description, we would register it? Right now? No.

	```ts
	const FooSchema = z.string().openapi({ ref: 'string' });
	const BarSchema = z.object({
	  a: FooSchema.describe('foo')
	});
	createSchema(BarSchema)
	```
	
	```ts
	{
	  schema: {
	    type: 'object',
	    properties: { b: { type: 'string', description: 'foo' } },
	    required: [ 'b' ]
	  },
	}
	```
	
	After:

	```ts
	{
	  schema: {
	    type: 'object',
	    properties: {
	      a: { '$ref': '#/components/schemas/string', description: 'foo' }
	    },
	    required: [ 'a', 'b' ]
	  },
	  components: { string: { type: 'string' } }
	}
	```
