### PR TITLE
Explicitly set additionalProperties for `.passthrough()`

### DIFF
--- a/src/create/schema/parsers/object.test.ts
+++ b/src/create/schema/parsers/object.test.ts
@@ -52,6 +52,35 @@ describe('createObjectSchema', () => {
     expect(result).toEqual(expected);
   });
 
+  it('supports passthrough', () => {
+    const expected: Schema = {
+      type: 'schema',
+      schema: {
+        type: 'object',
+        properties: {
+          a: {
+            type: 'string',
+          },
+        },
+        required: ['a'],
+        additionalProperties: true,
+      },
+    };
+    const schema = z
+      .object({
+        a: z.string(),
+      })
+      .passthrough();
+
+    const result = createObjectSchema(
+      schema,
+      undefined,
+      createOutputState(undefined),
+    );
+
+    expect(result).toEqual(expected);
+  });
+
   it('supports catchall', () => {
     const expected: Schema = {
       type: 'schema',

--- a/src/create/schema/parsers/transform.ts
+++ b/src/create/schema/parsers/transform.ts
@@ -225,7 +225,9 @@ export const verifyEffects = (effects: Effect[], state: SchemaState) => {
   }
 };
 
-export const flattenEffects = (effects: Array<Effect[] | undefined>) => {
+export const flattenEffects = (
+  effects: Array<Effect[] | undefined | false>,
+) => {
   const allEffects = effects.reduce<Effect[]>((acc, effect) => {
     if (effect) {
       return acc.concat(effect);


### PR DESCRIPTION
Sets `additionalProperties: true` to explicitly `true` when `.passthrough()` is added to a ZodObject.

https://github.com/fastify/fast-json-stringify#additional-properties

https://github.com/samchungy/fastify-zod-openapi/issues/224