### PR TITLE
Address poor meta performance

### DIFF
--- a/src/create/document.ts
+++ b/src/create/document.ts
@@ -40,8 +40,8 @@ export interface ZodOpenApiResponsesObject
   extends oas31.ISpecificationExtension {
   default?: ZodOpenApiResponseObject | oas31.ReferenceObject;
   [statuscode: `${1 | 2 | 3 | 4 | 5}${string}`]:
-  | ZodOpenApiResponseObject
-  | oas31.ReferenceObject;
+    | ZodOpenApiResponseObject
+    | oas31.ReferenceObject;
 }
 
 export type ZodOpenApiParameters = Partial<
@@ -195,9 +195,9 @@ export interface CreateDocumentOptions {
       OverrideType,
       | true
       | Partial<{
-        input: true;
-        output: true;
-      }>
+          input: true;
+          output: true;
+        }>
     >
   >;
 

--- a/src/create/schema/override.ts
+++ b/src/create/schema/override.ts
@@ -2,7 +2,10 @@ import type { GlobalMeta } from 'zod/v4';
 import type * as core from 'zod/v4/core';
 
 import type { CreateDocumentOptions } from '../../index.js';
-import type { ZodOpenApiOverride, ZodOpenApiOverrideContext } from '../../types.js';
+import type {
+  ZodOpenApiOverride,
+  ZodOpenApiOverrideContext,
+} from '../../types.js';
 
 import type { oas31 } from '@zod-openapi/openapi3-ts';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,9 +13,11 @@ export type ZodOpenApiOverrideContext = OverrideParameters & {
   io: 'input' | 'output';
 };
 
-export type ZodOpenApiOverrideSchemaContext = OverrideSchemaParameters
+export type ZodOpenApiOverrideSchemaContext = OverrideSchemaParameters;
 
-export type ZodOpenApiOverrideSchema = (ctx: ZodOpenApiOverrideSchemaContext) => void;
+export type ZodOpenApiOverrideSchema = (
+  ctx: ZodOpenApiOverrideSchemaContext,
+) => void;
 
 export type ZodOpenApiOverride = (ctx: ZodOpenApiOverrideContext) => void;
 
@@ -58,7 +60,7 @@ export interface ZodOpenApiBaseMetadata {
 
 export interface ZodOpenApiMetadata
   extends ZodOpenApiBaseMetadata,
-  JSONSchemaMeta {
+    JSONSchemaMeta {
   examples?: unknown[];
   /**
    * @deprecated - Use `examples` instead.
@@ -68,5 +70,5 @@ export interface ZodOpenApiMetadata
 }
 
 declare module 'zod/v4' {
-  interface GlobalMeta extends ZodOpenApiMetadata { }
+  interface GlobalMeta extends ZodOpenApiMetadata {}
 }


### PR DESCRIPTION
https://github.com/colinhacks/zod/blob/813451db7fcf64c5322835984eded9bfe95be1da/packages/zod/src/v4/classic/schemas.ts#L95-L97

These types here perform a replace and the zodSchemas union in here tank the performance for some reason. Probably isn't required in this context given the zod schema being processed will be itself.

Resolves https://github.com/samchungy/fastify-zod-openapi/issues/297