### PR TITLE
Fix `zod/mini` compatibility

### DIFF
--- a/.changeset/easy-crews-call.md
+++ b/.changeset/easy-crews-call.md
@@ -1,0 +1,5 @@
+---
+'zod-openapi': patch
+---
+
+Fix `zod/mini` compatibility

--- a/src/create/schema/override.ts
+++ b/src/create/schema/override.ts
@@ -1,4 +1,4 @@
-import { type GlobalMeta, globalRegistry } from 'zod/v4';
+import { globalRegistry } from 'zod/v4';
 import type * as core from 'zod/v4/core';
 
 import type { CreateDocumentOptions } from '../../index.js';

--- a/src/create/schema/override.ts
+++ b/src/create/schema/override.ts
@@ -1,4 +1,4 @@
-import type { GlobalMeta } from 'zod/v4';
+import { type GlobalMeta, globalRegistry } from 'zod/v4';
 import type * as core from 'zod/v4/core';
 
 import type { CreateDocumentOptions } from '../../index.js';
@@ -8,10 +8,6 @@ import type {
 } from '../../types.js';
 
 import type { oas31 } from '@zod-openapi/openapi3-ts';
-
-type ZodTypeWithMeta = core.$ZodTypes & {
-  meta: () => GlobalMeta | undefined;
-};
 
 export const override: ZodOpenApiOverride = (ctx) => {
   const def = ctx.zodSchema._zod.def;
@@ -68,7 +64,7 @@ export const override: ZodOpenApiOverride = (ctx) => {
           mapping;
       }
 
-      const meta = (ctx.zodSchema as ZodTypeWithMeta).meta();
+      const meta = globalRegistry.get(ctx.zodSchema);
 
       if (typeof meta?.unionOneOf === 'boolean') {
         if (meta.unionOneOf) {

--- a/src/create/schema/schema.ts
+++ b/src/create/schema/schema.ts
@@ -1,4 +1,10 @@
-import { type GlobalMeta, object, registry, toJSONSchema } from 'zod/v4';
+import {
+  type GlobalMeta,
+  globalRegistry,
+  object,
+  registry,
+  toJSONSchema,
+} from 'zod/v4';
 import type * as core from 'zod/v4/core';
 import type { $ZodType } from 'zod/v4/core';
 
@@ -19,10 +25,6 @@ export interface SchemaResult {
   schema: oas31.SchemaObject | oas31.ReferenceObject;
   components: Record<string, oas31.SchemaObject>;
 }
-
-type ZodTypeWithMeta = core.$ZodTypes & {
-  meta: () => GlobalMeta | undefined;
-};
 
 export const createSchema = (
   schema: core.$ZodType,
@@ -128,7 +130,7 @@ export const createSchemas = <
   const outputIds = new Map<string, string>();
   const jsonSchema = toJSONSchema(zodRegistry, {
     override(context) {
-      const meta = (context.zodSchema as ZodTypeWithMeta).meta();
+      const meta = globalRegistry.get(context.zodSchema);
       if (meta?.outputId && meta?.id) {
         // If the schema has an outputId, we need to replace it later
         outputIds.set(meta.id, meta.outputId);

--- a/src/create/schema/tests/mini.test.ts
+++ b/src/create/schema/tests/mini.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import * as z from 'zod/mini';
+
+import { type SchemaResult, createSchema } from '../schema.js';
+
+describe('mini default', () => {
+  it('creates a default string schema', () => {
+    const schema = z._default(z.string(), 'a').register(z.globalRegistry, {});
+
+    const result = createSchema(schema);
+
+    expect(result).toEqual<SchemaResult>({
+      schema: {
+        type: 'string',
+        default: 'a',
+      },
+      components: {},
+    });
+  });
+
+  it('adds a default property to a registered schema', () => {
+    const schema = z._default(
+      z.string().register(z.globalRegistry, { id: 'ref' }),
+      'a',
+    );
+
+    const result = createSchema(schema);
+
+    expect(result).toEqual<SchemaResult>({
+      schema: {
+        $ref: '#/components/schemas/ref',
+        default: 'a',
+      },
+      components: {
+        ref: {
+          type: 'string',
+        },
+      },
+    });
+  });
+});

--- a/src/create/schema/tests/unionMini.test.ts
+++ b/src/create/schema/tests/unionMini.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import * as z from 'zod/mini';
+
+import { createOutputContext } from '../../../testing/ctx.js';
+import { type SchemaResult, createSchema } from '../schema.js';
+
+describe('mini union', () => {
+  it('creates an anyOf schema for a union', () => {
+    const schema = z.union([z.string(), z.number()]);
+
+    const result = createSchema(schema);
+
+    expect(result).toEqual<SchemaResult>({
+      schema: {
+        anyOf: [
+          {
+            type: 'string',
+          },
+          {
+            type: 'number',
+          },
+        ],
+      },
+      components: {},
+    });
+  });
+
+  it('creates an oneOf schema for a union', () => {
+    const schema = z
+      .union([z.string(), z.number()])
+      .register(z.globalRegistry, {
+        override: ({ jsonSchema }) => {
+          jsonSchema.oneOf = jsonSchema.anyOf;
+          delete jsonSchema.anyOf;
+        },
+      });
+
+    const result = createSchema(schema);
+
+    expect(result).toEqual<SchemaResult>({
+      schema: {
+        oneOf: [
+          {
+            type: 'string',
+          },
+          {
+            type: 'number',
+          },
+        ],
+      },
+      components: {},
+    });
+  });
+
+  it('creates an oneOf schema for a union if a document option overrides it', () => {
+    const schema = z.union([z.string(), z.number()]);
+
+    const ctx = createOutputContext();
+    ctx.opts = {
+      override: ({ jsonSchema }) => {
+        jsonSchema.oneOf = jsonSchema.anyOf;
+        delete jsonSchema.anyOf;
+      },
+    };
+    const result = createSchema(schema, ctx);
+
+    expect(result).toEqual<SchemaResult>({
+      schema: {
+        oneOf: [
+          {
+            type: 'string',
+          },
+          {
+            type: 'number',
+          },
+        ],
+      },
+      components: {},
+    });
+  });
+
+  it('produces not values in a union', () => {
+    const schema = z.union([z.string(), z.never()]);
+
+    const result = createSchema(schema);
+
+    expect(result).toEqual<SchemaResult>({
+      schema: {
+        anyOf: [
+          {
+            type: 'string',
+          },
+          {
+            not: {},
+          },
+        ],
+      },
+      components: {},
+    });
+  });
+});


### PR DESCRIPTION
The correct way to read a schema's spec appears to be through `z.globalRegistry` instead of `.meta()`, which doesn't work for `zod/mini` types. I think the type assertion that was required with `meta()` points to the same conclusion.

Fixes #519