### PR TITLE
refactor: Redundant argument defaults in `createSchema`

### DIFF
--- a/src/create/schema/schema.ts
+++ b/src/create/schema/schema.ts
@@ -41,11 +41,7 @@ export const createSchema = (
      */
     schemaRefPath?: string;
     openapiVersion?: OpenApiVersion;
-  } = {
-    registry: createRegistry(),
-    io: 'output',
-    opts: {},
-  },
+  } = {},
 ) => {
   ctx.registry ??= createRegistry({
     schemas: ctx.schemaComponents,


### PR DESCRIPTION
The defaults were both in the default parameter value and later set using `??=`.

Note that the default for `registry` is a bit different for the following `??=` (hopefully better).