### PR TITLE
Fix compatibility with discriminatedUnions in Zod v4.1.13

### DIFF
--- a/src/create/schema/override.ts
+++ b/src/create/schema/override.ts
@@ -19,8 +19,15 @@ export const override: ZodOpenApiOverride = (ctx) => {
     }
     case 'union': {
       if ('discriminator' in def && typeof def.discriminator === 'string') {
-        ctx.jsonSchema.oneOf ??= ctx.jsonSchema.anyOf;
-        delete ctx.jsonSchema.anyOf;
+        // Handle both zod < 4.1.13 (anyOf) and zod >= 4.1.13 (oneOf)
+        // See: https://github.com/colinhacks/zod/pull/5453
+        if (!ctx.jsonSchema.oneOf && ctx.jsonSchema.anyOf) {
+          ctx.jsonSchema.oneOf = ctx.jsonSchema.anyOf;
+          delete ctx.jsonSchema.anyOf;
+        } else if (!ctx.jsonSchema.oneOf) {
+          // Neither oneOf nor anyOf exists - skip discriminator mapping
+          return;
+        }
 
         ctx.jsonSchema.type = 'object';
 


### PR DESCRIPTION
The patch introduced in Zod [here](https://github.com/colinhacks/zod/pull/5453) for fixing the previously-incorrect behavior in Zod v4.1.12 now breaks the generation of OpenAPI schemas for any `z.discriminatedUnion` with:

```
TypeError: Cannot convert undefined or null to object
    at Object.entries (<anonymous>)
    at override (file:///<project root>/node_modules/zod-openapi/dist/components-DV_-zLJ6.js:206:39)
    at Object.override (file:///<project root>/node_modules/zod-openapi/dist/components-DV_-zLJ6.js:372:4)
    at flattenRef (file:///<project root>/node_modules/zod/v4/core/to-json-schema.js:289:13)
    at finalize (file:///<project root>/node_modules/zod/v4/core/to-json-schema.js:296:9)
    at toJSONSchema (file:///<project root>/node_modules/zod/v4/core/json-schema-processors.js:590:28)
    at createSchemas (file:///<project root>/node_modules/zod-openapi/dist/components-DV_-zLJ6.js:363:21)
    at createIOSchemas (file:///<project root>/node_modules/zod-openapi/dist/components-DV_-zLJ6.js:868:42)
    at createComponents (file:///<project root>/node_modules/zod-openapi/dist/components-DV_-zLJ6.js:888:2)
    at Object.fastifyZodOpenApiTransformObject [as transformObject] (file:///<project root>/node_modules/fastify-zod-openapi/dist/index.mjs:437:22)
```

This PR enables forward-compatibility by handling both versions of Zod correctly.
