### PR TITLE
Fix issue on `override.ts` with `ctx.jsonSchema.anyOf` being undefined or null

### DIFF
--- a/src/create/schema/override.ts
+++ b/src/create/schema/override.ts
@@ -21,7 +21,7 @@ export const override: ZodOpenApiOverride = (ctx) => {
     }
     case 'union': {
       if ('discriminator' in def && typeof def.discriminator === 'string') {
-        ctx.jsonSchema.oneOf ??= ctx.jsonSchema.anyOf;
+        ctx.jsonSchema.oneOf ??= ctx.jsonSchema.anyOf ?? {};
         delete ctx.jsonSchema.anyOf;
 
         ctx.jsonSchema.type = 'object';


### PR DESCRIPTION
This was causing an issue with zod 4.2 versions where `anyOf` might have been null or undefined:

```
TypeError: Cannot convert undefined or null to object
 ❯ override ../../node_modules/zod-openapi/dist/components-DV_-zLJ6.js:206:39
 ❯ Object.override ../../node_modules/zod-openapi/dist/components-DV_-zLJ6.js:372:4
 ❯ flattenRef ../../node_modules/zod/v4/core/to-json-schema.js:289:13
 ❯ finalize ../../node_modules/zod/v4/core/to-json-schema.js:296:9
 ❯ toJSONSchema ../../node_modules/zod/v4/core/json-schema-processors.js:590:28
 ❯ createSchemas ../../node_modules/zod-openapi/dist/components-DV_-zLJ6.js:363:21
 ❯ createIOSchemas ../../node_modules/zod-openapi/dist/components-DV_-zLJ6.js:868:42
 ❯ createComponents ../../node_modules/zod-openapi/dist/components-DV_-zLJ6.js:888:2
 ❯ createDocument ../../node_modules/zod-openapi/dist/index.js:12:28
```

Error came from `Object.entries()` call on: https://github.com/samchungy/zod-openapi/blob/master/src/create/schema/override.ts#L34-L36
